### PR TITLE
fix: linter errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,9 @@
 module.exports = {
   env: {
+    node: true,
     browser: true,
     'cypress/globals': true,
+    es6: true,
   },
   extends: [
     'eslint:recommended',

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+# npm packages
 node_modules
-dist
-README.publishnpm
-cypress/config.js
 
+# builds
+dist
+
+# integration tests
+cypress/config.js
+cypress/videos/
+cypress/screenshots
+
+
+README.publishnpm

--- a/src/CLIENT.js
+++ b/src/CLIENT.js
@@ -1,5 +1,4 @@
 import Call from "./Call.js";
-import Utils from "./Utils.js";
 import Logger from "./Logger.js";
 
 var __VERSION__ = process.env.VERSIONSTR; // webpack defineplugin variable
@@ -76,7 +75,7 @@ var CLIENT = function(configuration = {}) {
     this._onError({ origin: "CLIENT", message: "Please provide an apiKey" });
   }
 
-  if (!"WebSocket" in window) {
+  if (!("WebSocket" in window)) {
     this._onError({ origin: "CLIENT", message: "WebSocket not supported" });
   }
 
@@ -209,6 +208,7 @@ const handleWebSocketMessage = function(event) {
         1000
       ).toFixed(0);
 
+      // eslint-disable-next-line no-console
       console.info(
         "Speed Test: Up: " + up_kps + "kbit/s Down: " + down_kps + "kbits/s"
       );
@@ -504,6 +504,7 @@ const handleVertoEvent = function(event) {
 
   if (index >= 0) {
     if (/^conference-liveArray/.test(event.params.eventChannel)) {
+      // eslint-disable-next-line no-console
       console.log("event.params.data : ", JSON.stringify(event.params.data));
 
       let data = event.params.data.data;
@@ -616,7 +617,7 @@ const handleConferenceListResponse = function(event, callID) {
 /**
  * Log connection event, update status, call CLIENT.onDisconnected()
  */
-const handleWebSocketClose = function(err) {
+const handleWebSocketClose = function() {
   LOGGER.log("handleWebSocketClose | WebSocket closed");
   this._status = STATUS_INIT;
   this._onDisconnected();
@@ -657,9 +658,6 @@ const shutdown = function() {
 };
 
 const sendText = function({ text, userKeys = {} }, userCallback) {
-  var text = text;
-  var userKeys = typeof userKeys !== "object" ? {} : userKeys;
-
   this._sendTextCallback = userCallback;
 
   var request = {};
@@ -669,7 +667,7 @@ const sendText = function({ text, userKeys = {} }, userCallback) {
   request.params = {
     type: "sendtext_request",
     text: text,
-    userKeys: userKeys
+    userKeys: typeof userKeys !== "object" ? {} : userKeys
   };
 
   this._sendMessage(JSON.stringify(request));
@@ -677,7 +675,7 @@ const sendText = function({ text, userKeys = {} }, userCallback) {
 
 const getWebsocketServer = function() {
   try {
-    var matches = this._wsUrl.match(/^wss?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i);
+    var matches = this._wsUrl.match(/^wss?:\/\/([^/:?#]+)(?:[/:?#]|$)/i);
     var host = matches && matches[1];
 
     return host;

--- a/src/Call.js
+++ b/src/Call.js
@@ -8,9 +8,6 @@ var __VERSION__ = process.env.VERSIONSTR; // webpack defineplugin variable
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new Logger(false, LOG_PREFIX);
 
-var APIDAZE_SCREENSHARE_CHROME_EXTENSION_ID =
-  "ecomagggebppeikobjchgmnoldifjnjj";
-
 /**
  * The callID parameter is expected to be null, except when clientObj is
  * re-attaching to an existing call in FreeSWITCH
@@ -27,7 +24,6 @@ var Call = function(clientObj, callID, params, listeners) {
   var {
     tagId = "apidaze-audio-video-container-id-" + randomString,
     audioParams = {},
-    userKeys
   } = params;
 
   var {
@@ -87,7 +83,7 @@ var Call = function(clientObj, callID, params, listeners) {
     LOGGER.log(
       "Inserting HTML5 <video/> element (audio only) to APIdaze tag " + tagId
     );
-    var audioVideoDOMContainerObj = document.createElement("div");
+    audioVideoDOMContainerObj = document.createElement("div");
     audioVideoDOMContainerObj.id = tagId;
     audioVideoDOMContainerObj.appendChild(this.remoteAudioVideo);
 
@@ -258,7 +254,7 @@ function _publishOwnVideoFeed(useAudio) {
   });
 }
 
-function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
+function _attachJanusVideoPlugin(callbackSuccess) {
   var self = this;
 
   // FIXME: need to figure out how to set opaqueId
@@ -276,7 +272,6 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
           ")"
       );
       Janus.log("  -- This is a publisher/manager");
-      var create = { request: "exists", room: self.janusVideoRoomID };
       self.janusVideoPlugin.send({
         message: {
           request: "exists",
@@ -292,7 +287,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
                 // FIXME : allow dev to add username here
                 //"display": 'phil'
               },
-              success: function(result) {
+              success: function() {
                 LOGGER.log("JOINED ROOM FOR VIDEO");
                 typeof callbackSuccess === "function" && callbackSuccess();
               }
@@ -306,7 +301,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
                 // FIXME : allow dev to add username here
                 // "display": 'phil'
               },
-              success: function(result) {
+              success: function() {
                 LOGGER.log("ROOM CREATED FOR VIDEO");
                 self.janusVideoPlugin.send({
                   message: {
@@ -315,7 +310,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
                     ptype: "publisher",
                     display: "phil"
                   },
-                  success: function(result) {
+                  success: function() {
                     LOGGER.log("JOINED ROOM FOR VIDEO");
                     typeof callbackSuccess === "function" && callbackSuccess();
                   }
@@ -332,6 +327,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
     consentDialog: function(on) {
       Janus.debug("Consent dialog should be " + (on ? "on" : "off") + " now");
       if (on) {
+        // eslint-disable-next-line no-console
         console.log("Ask consent");
         // Darken screen and show hint
         /*
@@ -347,6 +343,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
 						} });
             */
       } else {
+        // eslint-disable-next-line no-console
         console.log("Ask consent");
         // Restore screen
         // $.unblockUI();
@@ -367,7 +364,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
     onmessage: function(msg, jsep) {
       Janus.debug(" ::: Got a message (publisher) :::");
       Janus.debug(msg);
-      var event = msg["videoroom"];
+      let event = msg["videoroom"];
       Janus.debug("Event: " + event);
       if (event != undefined && event != null) {
         if (event === "joined") {
@@ -378,14 +375,14 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
           //            _publishOwnVideoFeed.call(self, false);
           // Any new feed to attach to?
           if (msg["publishers"] !== undefined && msg["publishers"] !== null) {
-            var list = msg["publishers"];
+            let list = msg["publishers"];
             Janus.debug("Got a list of available publishers/feeds:");
             Janus.debug(list);
-            for (var f in list) {
-              var id = list[f]["id"];
-              var display = list[f]["display"];
-              var audio = list[f]["audio_codec"];
-              var video = list[f]["video_codec"];
+            for (let f in list) {
+              let id = list[f]["id"];
+              let display = list[f]["display"];
+              let audio = list[f]["audio_codec"];
+              let video = list[f]["video_codec"];
               Janus.debug(
                 "  >> [" +
                   id +
@@ -406,14 +403,14 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
         } else if (event === "event") {
           // Any new feed to attach to?
           if (msg["publishers"] !== undefined && msg["publishers"] !== null) {
-            var list = msg["publishers"];
+            let list = msg["publishers"];
             Janus.debug("Got a list of available publishers/feeds:");
             Janus.debug(list);
-            for (var f in list) {
-              var id = list[f]["id"];
-              var display = list[f]["display"];
-              var audio = list[f]["audio_codec"];
-              var video = list[f]["video_codec"];
+            for (let f in list) {
+              let id = list[f]["id"];
+              let display = list[f]["display"];
+              let audio = list[f]["audio_codec"];
+              let video = list[f]["video_codec"];
               Janus.debug(
                 "  >> [" +
                   id +
@@ -429,10 +426,10 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
             }
           } else if (msg["leaving"] !== undefined && msg["leaving"] !== null) {
             // One of the publishers has gone away?
-            var leaving = msg["leaving"];
+            let leaving = msg["leaving"];
             Janus.log("Publisher left: " + leaving);
-            var remoteFeed = null;
-            for (var i = 1; i < 6; i++) {
+            let remoteFeed = null;
+            for (let i = 1; i < 6; i++) {
               if (
                 self.janusFeeds[i] != null &&
                 self.janusFeeds[i] != undefined &&
@@ -458,15 +455,15 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
             msg["unpublished"] !== null
           ) {
             // One of the publishers has unpublished?
-            var unpublished = msg["unpublished"];
+            let unpublished = msg["unpublished"];
             Janus.log("Publisher left: " + unpublished);
             if (unpublished === "ok") {
               // That's us
               self.janusVideoPlugin.hangup();
               return;
             }
-            var remoteFeed = null;
-            for (var i = 1; i < 6; i++) {
+            let remoteFeed = null;
+            for (let i = 1; i < 6; i++) {
               if (
                 self.janusFeeds[i] != null &&
                 self.janusFeeds[i] != undefined &&
@@ -510,7 +507,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
         self.janusVideoPlugin.handleRemoteJsep({ jsep: jsep });
         // Check if any of the media we wanted to publish has
         // been rejected (e.g., wrong or unsupported codec)
-        var audio = msg["audio_codec"];
+        let audio = msg["audio_codec"];
         if (
           self.janusVideoStream &&
           self.janusVideoStream.getAudioTracks() &&
@@ -522,7 +519,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
             "Our audio stream has been rejected, viewers won't hear us"
           );
         }
-        var video = msg["video_codec"];
+        let video = msg["video_codec"];
         if (
           self.janusVideoStream &&
           self.janusVideoStream.getVideoTracks() &&
@@ -541,9 +538,6 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
 
       let localVideoElement = document.querySelector(
         `#${self.janusVideoOptions.localVideoContainerId} video`
-      );
-      let remoteVideosContainerElement = document.querySelector(
-        `#${self.janusVideoOptions.remoteVideosContainerId}`
       );
 
       if (
@@ -568,6 +562,7 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
           "completed" &&
         self.janusVideoPlugin.webrtcStuff.pc.iceConnectionState !== "connected"
       ) {
+        // eslint-disable-next-line no-console
         console.log("Publishing video...");
       }
       var videoTracks = stream.getVideoTracks();
@@ -577,12 +572,14 @@ function _attachJanusVideoPlugin(callbackSuccess, callbackError) {
         videoTracks.length === 0
       ) {
         // No webcam
+        // eslint-disable-next-line no-console
         console.log("No webcam");
       } else {
+        // eslint-disable-next-line no-console
         console.log("Need webcam");
       }
     },
-    onremotestream: function(stream) {
+    onremotestream: function() {
       // The publisher stream is sendonly, we don't expect anything here
     },
     oncleanup: function() {
@@ -628,6 +625,7 @@ function _newRemoteFeed(id, display, audio, video) {
         Janus.webRTCAdapter.browserDetails.browser === "safari"
       ) {
         if (video) video = video.toUpperCase();
+        // eslint-disable-next-line no-console
         console.log(
           "Publisher is using " +
             video +
@@ -639,7 +637,8 @@ function _newRemoteFeed(id, display, audio, video) {
     },
     error: function(error) {
       Janus.error("  -- Error attaching plugin...", error);
-      bootbox.alert("Error attaching plugin... " + error);
+      // eslint-disable-next-line no-console
+      console.error("Error attaching plugin... " + error);
     },
     onmessage: function(msg, jsep) {
       Janus.debug(" ::: Got a message (subscriber) :::");
@@ -647,7 +646,8 @@ function _newRemoteFeed(id, display, audio, video) {
       var event = msg["videoroom"];
       Janus.debug("Event: " + event);
       if (msg["error"] !== undefined && msg["error"] !== null) {
-        bootbox.alert(msg["error"]);
+        // eslint-disable-next-line no-console
+        console.error(msg["error"]);
       } else if (event != undefined && event != null) {
         if (event === "attached") {
           // Subscriber created and attached
@@ -700,10 +700,10 @@ function _newRemoteFeed(id, display, audio, video) {
             if (!remoteFeed.simulcastStarted) {
               remoteFeed.simulcastStarted = true;
               // Add some new buttons
-              addSimulcastButtons(remoteFeed.rfindex);
+              // addSimulcastButtons(remoteFeed.rfindex);
             }
             // We just received notice that there's been a switch, update the buttons
-            updateSimulcastButtons(remoteFeed.rfindex, substream, temporal);
+            // updateSimulcastButtons(remoteFeed.rfindex, substream, temporal);
           }
         } else {
           // What has just happened?
@@ -726,7 +726,8 @@ function _newRemoteFeed(id, display, audio, video) {
           },
           error: function(error) {
             Janus.error("WebRTC error:", error);
-            bootbox.alert("WebRTC error... " + JSON.stringify(error));
+            // eslint-disable-next-line no-console
+            console.error("WebRTC error... " + JSON.stringify(error));
           }
         });
       }
@@ -740,12 +741,11 @@ function _newRemoteFeed(id, display, audio, video) {
           " now"
       );
     },
-    onlocalstream: function(stream) {
+    onlocalstream: function() {
       // The subscriber stream is recvonly, we don't expect anything here
     },
     onremotestream: function(stream) {
       Janus.debug("Remote feed #" + remoteFeed.rfindex);
-      var addButtons = false;
       const target = document.querySelector(
         `#${self.janusVideoOptions.remoteVideosContainerId} div[remoteid='${
           remoteFeed.rfindex
@@ -753,7 +753,6 @@ function _newRemoteFeed(id, display, audio, video) {
       );
       //if($('#remotevideo'+remoteFeed.rfindex).length === 0) {
       if (target.length === 0 || typeof target.length === "undefined") {
-        addButtons = true;
         // No remote video yet
         let innerHTML =
           '<video id="remotevideo' +
@@ -1216,10 +1215,12 @@ function setRemoteDescription(sdp) {
         sdp: sdp
       },
       function() {
+        // eslint-disable-next-line no-console
         console.log("ok");
       },
       function(error) {
-        console.log("err");
+        // eslint-disable-next-line no-console
+        console.log("err", error);
       }
     )
   );

--- a/src/Call.js
+++ b/src/Call.js
@@ -23,7 +23,7 @@ var Call = function(clientObj, callID, params, listeners) {
 
   var {
     tagId = "apidaze-audio-video-container-id-" + randomString,
-    audioParams = {},
+    audioParams = {}
   } = params;
 
   var {
@@ -1226,44 +1226,6 @@ function setRemoteDescription(sdp) {
   );
 }
 
-/**
- * Create and answer for FreeSWITCH
- *
- * This function is called when FeeSWICTH sent its SDP first. In the case
- * where we need to re attach a verto session to an existing call, this
- * function will be called.
- */
-function createAnswer() {
-  var offerOptions = {
-    offerToReceiveAudio: 1,
-    offerToReceiveVideo: 1
-  };
-
-  var self = this;
-
-  this.peerConnection
-    .setRemoteDescription(
-      new RTCSessionDescription({
-        type: "offer",
-        sdp: self.clientObj._reattachParams.sdp
-      })
-    )
-    .then(function() {
-      LOGGER.log("RTCSessionDescription created");
-      return self.peerConnection.createAnswer();
-    })
-    .then(function(answer) {
-      LOGGER.log("createAnswer returned successfully");
-      return self.peerConnection.setLocalDescription(answer);
-    })
-    .then(function() {
-      LOGGER.log("setLocalDescription returned successfully");
-    })
-    .catch(function(err) {
-      LOGGER.log("Error : " + JSON.stringify(err));
-    });
-}
-
 function attachStreamToPeerConnection() {
   let self = this;
   this.localAudioVideoStream.getTracks().forEach(function(track) {
@@ -1353,7 +1315,6 @@ function startCall() {
  */
 function handleHangup() {
   LOGGER.log("Call hungup");
-  let self = this;
 
   if (
     this.extraLocalAudioVideoStream &&
@@ -1392,7 +1353,7 @@ function handleRoomChatMessage(message) {
   delete message.type;
 
   typeof this.userRoomChatMessageCallback === "function" &&
-    this.userRoomChatMessageCallback(msg);
+    this.userRoomChatMessageCallback(message);
 }
 
 function handleMembersInitialList(members) {
@@ -1421,7 +1382,6 @@ function handleRoomTalking(dataArray) {
 
 function handleRoomAdd(dataArray) {
   LOGGER.log("Add event : " + JSON.stringify(dataArray));
-  var status = JSON.parse(dataArray[4]);
   var event = {
     type: "room.add",
     conferenceMemberID: parseInt(dataArray[0]).toString(),
@@ -1436,7 +1396,6 @@ function handleRoomAdd(dataArray) {
 
 function handleRoomDel(dataArray) {
   LOGGER.log("Del event : " + JSON.stringify(dataArray));
-  var status = JSON.parse(dataArray[4]);
   var event = {
     type: "room.del",
     conferenceMemberID: parseInt(dataArray[0]).toString(),
@@ -1449,19 +1408,14 @@ function handleRoomDel(dataArray) {
     this.userRoomDelCallback(event);
 }
 
-function handleRinging(userCallback) {
+function handleRinging() {
   LOGGER.log("Ringing");
   typeof this.userRingingCallback === "function" && this.userRingingCallback();
 }
 
-function handleAnswer(userCallback) {
+function handleAnswer() {
   LOGGER.log("Answer");
   typeof this.userAnswerCallback === "function" && this.userAnswerCallback();
-}
-
-function handleGUMSuccess(stream) {
-  LOGGER.log("WebRTC Ok");
-  this.localAudioVideoStream = stream;
 }
 
 function handleGUMError(error) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -6,6 +6,7 @@ var Logger = function(debug, prefix) {
     if (this._debug) {
       var args = Array.prototype.slice.call(arguments);
       args.unshift(prefix + " ");
+      // eslint-disable-next-line no-console
       console.log.apply(console, args);
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,8 @@
 import CLIENT from "./CLIENT.js";
 import * as WebRTCAdapter from "webrtc-adapter";
-import Logger from "./Logger.js";
 
 var __VERSION__ = process.env.VERSIONSTR; // webpack defineplugin variable
 var version = __VERSION__;
-
-var LOG_PREFIX = "APIdaze-" + __VERSION__;
 
 const isWebRTCSupported = function() {
   return (


### PR DESCRIPTION
Closes #7

Most mind boggling was `bootbox.alert("Error attaching plugin... " + error);`. The object `bootbox` has no presence in dependencies (and any other place of project) and it's invocation of [library for modals](http://bootboxjs.com/). As a proposed solution `console.error` is used, as in many other places.

Cypress (integration test suite) can record videos and screenshots of failed tests. The change in gitignore is to exclude them from commits.