### PR TITLE
fix: error on video conference leave

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "https://localhost:9000"
+  "baseUrl": "https://localhost:9000",
+  "defaultCommandTimeout": 6000
 }

--- a/cypress/integration/samples.spec.js
+++ b/cypress/integration/samples.spec.js
@@ -133,6 +133,7 @@ describe('examples', () => {
     cy.get('#output').should("contain", 'Call | Received remote stream');
     cy.get('#output').should("contain", 'Call | ICE State : connected');
     cy.get('#output').should("contain", 'Call | ICE State : completed');
+    cy.wait(500);
     cy.get('#output').should("contain", '"method":"event","params":{"pvtData":{"action":"conference-liveArray-join"');
     cy.get('#output').should("contain", 'Received event of type channelPvtData');
     cy.get('#output').should("contain", 'Event channel UUID');

--- a/cypress/integration/samples.spec.js
+++ b/cypress/integration/samples.spec.js
@@ -34,10 +34,9 @@ describe('examples', () => {
     cy.get('#output').should("contain", `handleWebSocketMessage | C->S : {"wsp_version":"1","method":"ping","params":{"apiKey":"${config.key}","sessid":null,"userKeys":{"command":"auth","userid":"username"}}}`);
     cy.get('#output').should("contain", 'message":"pong"');
     cy.get('#output').should("contain", '"method":"verto.clientReady"');
-    cy.get('#output').should("contain", '"id":"username"');
     cy.get('#output').should("contain", 'Ready');
     cy.wait(100).then(() => {
-      expect(stub.getCall(0)).to.be.calledWith('Logged in as username !');
+      expect(stub.getCall(0).args[0]).to.match(/Logged in with session id /);
     });
   })
 
@@ -93,7 +92,6 @@ describe('examples', () => {
     cy.get('#output').should("contain", `handleWebSocketMessage | C->S : {"wsp_version":"1","method":"ping","params":{"apiKey":"${config.key}","sessid":null,"userKeys":{"command":"auth","userid":"username"}}}`);
     cy.get('#output').should("contain", 'message":"pong"');
     cy.get('#output').should("contain", '"method":"verto.clientReady"');
-    cy.get('#output').should("contain", '"id":"username"');
     cy.get('#output').should("contain", 'Ready');
   })
 
@@ -133,7 +131,6 @@ describe('examples', () => {
     cy.get('#output').should("contain", 'Call | Received remote stream');
     cy.get('#output').should("contain", 'Call | ICE State : connected');
     cy.get('#output').should("contain", 'Call | ICE State : completed');
-    cy.wait(500);
     cy.get('#output').should("contain", '"method":"event","params":{"pvtData":{"action":"conference-liveArray-join"');
     cy.get('#output').should("contain", 'Received event of type channelPvtData');
     cy.get('#output').should("contain", 'Event channel UUID');

--- a/samples/apikey_check_and_login/console.html
+++ b/samples/apikey_check_and_login/console.html
@@ -26,7 +26,7 @@ var APIdazeClientObj = new APIdaze.CLIENT({
     userid: userid
   },
   onReady: function(sessionObj) {
-    alert("Logged in as " + sessionObj.id + " !");
+    alert("Logged in with session id " + sessionObj.id + " !");
   },
   onError: function(errorMessage){
     alert("Got error : " + errorMessage);

--- a/samples/apikey_check_and_login/index.html
+++ b/samples/apikey_check_and_login/index.html
@@ -75,7 +75,7 @@
             userid: userNameObj.value
           },
           onReady: function(sessionObj) {
-            alert("Logged in as " + sessionObj.id + " !");
+            alert("Logged in with session id " + sessionObj.id + " !");
             toggleInputs();
           },
           onError: function(errorMessage){

--- a/src/CLIENT.js
+++ b/src/CLIENT.js
@@ -360,7 +360,7 @@ const handleWebSocketMessage = function(event) {
     return callObj.callID === callID;
   });
 
-  if (json.params && json.params.callID && index < 0) {
+  if (callID && index < 0) {
     LOGGER.log("Cannot find call with callID " + callID);
   }
 

--- a/src/CLIENT.js
+++ b/src/CLIENT.js
@@ -355,12 +355,12 @@ const handleWebSocketMessage = function(event) {
     return;
   }
 
-  let callID = json.params.callID;
+  let callID = json.params && json.params.callID;
   let index = this._callArray.findIndex(function(callObj) {
     return callObj.callID === callID;
   });
 
-  if (index < 0) {
+  if (json.params && json.params.callID && index < 0) {
     LOGGER.log("Cannot find call with callID " + callID);
   }
 


### PR DESCRIPTION
Closes: #8 

Error happens because unsubscribe event doesn't have a callID. I tried to add blank case matching \^unsubscribe\ event id that would exit from function which is handling the events, but that changed logs a bit in integration tests ('CALL ENDED' was no longer present) so I used simple condition instead.