### PR TITLE
fix: Make Utils.hashCode's return unsigned int

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -50,10 +50,16 @@ Utils.generateGUID =
  * positive integers as room identifiers
  */
 Utils.hashCode = function(s) {
-  return s.split("").reduce(function(a, b) {
+  let result = s.split("").reduce(function(a, b) {
     a = (a << 5) - a + b.charCodeAt(0);
     return a & a;
   }, 0);
+
+  if (result < 0) {
+    result = result >>> 0;
+  }
+
+  return result;
 };
 
 export default Utils;


### PR DESCRIPTION
As mentioned in the comment above the `Utils.hashCode`, 

> Janus only accepts positive integers as room identifiers

But the current `hashCode` method may return a negative integer as it returns Int32 instead of UInt32. Therefore, I have extended the current implementation with the unsigned shift right approach.