### PR TITLE
feat: Accept new tracks during calls

### DIFF
--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -982,6 +982,8 @@ var _Logger2 = _interopRequireDefault(_Logger);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
 var STATUS_INIT = 1;
@@ -1013,12 +1015,17 @@ var CLIENT = function CLIENT() {
       debug = configuration.debug,
       _configuration$userKe = configuration.userKeys,
       userKeys = _configuration$userKe === undefined ? {} : _configuration$userKe,
-      iceServers = configuration.iceServers;
+      _configuration$iceSer = configuration.iceServers,
+      iceServers = _configuration$iceSer === undefined ? [{ urls: "stun:stun.l.google.com:19302" }] : _configuration$iceSer;
+
+
+  if (iceServers === null) {
+    iceServers = [];
+  }
 
   /**
    * Functions exposed to user
    */
-
   this.speedTest = speedTest.bind(this);
   this.ping = ping.bind(this);
   this.shutdown = shutdown.bind(this);
@@ -1026,6 +1033,8 @@ var CLIENT = function CLIENT() {
   this.disconnect = shutdown.bind(this); // disconnect is kept for compatibility reasons
   this.sendText = sendText.bind(this);
   this.getWebsocketServer = getWebsocketServer.bind(this);
+  this.enumerateDevices = enumerateDevices;
+  this.enumerateAudioDevices = enumerateAudioDevices;
 
   // User defined handlers
   this._onDisconnected = function () {
@@ -1715,6 +1724,52 @@ var computeWebsocketServerUrl = function computeWebsocketServerUrl() {
   return defaultServerUrl;
 };
 
+/**
+ * Get the media devices
+ *
+ * @param {Object} options - Options to indicate what kind of devices should be returned
+ * @param {Boolean} [options.audio] - Indicates if audio devices should be included
+ * @param {Boolean} [options.video] - Indicates if video devices should be included
+ *
+ * @return {Promise} Promise object to provide media devices
+ */
+function enumerateDevices(_ref2) {
+  var _ref2$audio = _ref2.audio,
+      audio = _ref2$audio === undefined ? true : _ref2$audio,
+      _ref2$video = _ref2.video,
+      video = _ref2$video === undefined ? false : _ref2$video;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.enumerateDevices().then(function (devices) {
+      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
+        var kind = currentDevice.kind;
+
+
+        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        if (video && kind === "videoinput") {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        return reducedDevices;
+      }, []);
+
+      resolve(filteredDevices);
+    }).catch(reject);
+  });
+}
+
+/**
+ * Get the audio devices
+ *
+ * @return {Promise} Promise object to provide audio media devices
+ */
+function enumerateAudioDevices() {
+  return enumerateDevices({ audio: true });
+}
+
 exports.default = CLIENT;
 
 /***/ }),
@@ -1744,11 +1799,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
-
-
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
+// eslint-disable-next-line no-unused-vars
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
@@ -1769,10 +1822,15 @@ var Call = function Call(clientObj, callID, params, listeners) {
 
   var _params$activateAudio = params.activateAudio,
       activateAudio = _params$activateAudio === undefined ? true : _params$activateAudio,
+      audioInputDeviceId = params.audioInputDeviceId,
+      audioOutputDeviceId = params.audioOutputDeviceId,
+      videoInputDeviceId = params.videoInputDeviceId,
       _params$tagId = params.tagId,
       tagId = _params$tagId === undefined ? "apidaze-audio-video-container-id-" + randomString : _params$tagId,
       _params$audioParams = params.audioParams,
-      audioParams = _params$audioParams === undefined ? {} : _params$audioParams;
+      audioParams = _params$audioParams === undefined ? {} : _params$audioParams,
+      _params$iceServers = params.iceServers,
+      iceServers = _params$iceServers === undefined ? clientObj._iceServers : _params$iceServers;
 
 
   var videoParams = {
@@ -1805,6 +1863,7 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.activateAudio = activateAudio;
   this.videoParams = videoParams;
   this.audioParams = audioParams;
+  this.iceServers = iceServers;
   this.audioVideoTagId = tagId;
 
   var audioVideoDOMContainerObj = document.getElementById(tagId);
@@ -1818,6 +1877,10 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.remoteAudioVideo.controls = false;
   if (this.activateVideo === false) {
     this.remoteAudioVideo.style.display = "none";
+  }
+
+  if (audioOutputDeviceId && typeof audioOutputDeviceId === 'string' && audioOutputDeviceId.length > 0) {
+    attachSinkId(this.remoteAudioVideo, audioOutputDeviceId);
   }
 
   if (audioVideoDOMContainerObj == null) {
@@ -1875,8 +1938,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.startLocalAudio = startLocalAudio;
   this.stopLocalVideo = stopLocalVideo;
   this.startLocalVideo = startLocalVideo;
-  this.enumerateDevices = enumerateDevices;
-  this.enumerateAudioDevices = enumerateAudioDevices;
   this.setAudioInputDevice = setAudioInputDevice;
   this.setAudioOutputDevice = setAudioOutputDevice;
 
@@ -1888,8 +1949,22 @@ var Call = function Call(clientObj, callID, params, listeners) {
     audio: this.activateAudio
   };
 
+  if (this.activateAudio && audioInputDeviceId && typeof audioInputDeviceId === 'string' && audioInputDeviceId.length > 0) {
+    GUMConstraints.audio = {
+      deviceId: {
+        exact: audioInputDeviceId
+      }
+    };
+  }
+
   if (this.activateVideo === false) {
     GUMConstraints.video = false;
+  } else if (videoInputDeviceId && typeof videoInputDeviceId === 'string' && videoInputDeviceId.length > 0) {
+    GUMConstraints.video = {
+      deviceId: {
+        exact: videoInputDeviceId
+      }
+    };
   } else {
     LOGGER.log("Need to set GUMConstraints.video");
     GUMConstraints.video = {
@@ -2022,52 +2097,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
     });
   }
 };
-
-/**
- * Get the media devices
- *
- * @param {Object} options - Options to indicate what kind of devices should be returned
- * @param {Boolean} [options.audio] - Indicates if audio devices should be included
- * @param {Boolean} [options.video] - Indicates if video devices should be included
- *
- * @return {Promise} Promise object to provide media devices
- */
-function enumerateDevices(_ref) {
-  var _ref$audio = _ref.audio,
-      audio = _ref$audio === undefined ? true : _ref$audio,
-      _ref$video = _ref.video,
-      video = _ref$video === undefined ? false : _ref$video;
-
-  return new Promise(function (resolve, reject) {
-    navigator.mediaDevices.enumerateDevices().then(function (devices) {
-      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
-        var kind = currentDevice.kind;
-
-
-        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        if (video && kind === "videoinput") {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        return reducedDevices;
-      }, []);
-
-      resolve(filteredDevices);
-    }).catch(reject);
-  });
-}
-
-/**
- * Get the audio devices
- *
- * @return {Promise} Promise object to provide audio media devices
- */
-function enumerateAudioDevices() {
-  return enumerateDevices({ audio: true });
-}
 
 /**
  * Sets the ID of the audio device to use for output on the given mediaElement
@@ -2453,7 +2482,7 @@ function attachStreamToPeerConnection() {
  * function.
  */
 function createPeerConnection() {
-  var pc_config = { iceServers: [{ urls: "stun:stun.l.google.com:19302" }] };
+  var pc_config = { iceServers: this.iceServers };
   var pc_constraints = {
     optional: [{ DtlsSrtpKeyAgreement: true }, { googIPv6: false }],
     mandatory: {

--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -989,13 +989,23 @@ var STATUS_READY = 2;
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
+var REGIONS = {
+  "us-east": "us1",
+  "us-west": "us2",
+  "eu-central": "eu1",
+  "eu-west": "eu2",
+  "ap-southeast": "ap1"
+};
+
 var CLIENT = function CLIENT() {
   var configuration = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var apiKey = configuration.apiKey,
-      wsurl = configuration.wsurl,
-      forcewsurl = configuration.forcewsurl,
+      _configuration$wsurl = configuration.wsurl,
+      wsurl = _configuration$wsurl === undefined ? undefined : _configuration$wsurl,
       _configuration$sessid = configuration.sessid,
       sessid = _configuration$sessid === undefined ? null : _configuration$sessid,
+      _configuration$region = configuration.region,
+      region = _configuration$region === undefined ? undefined : _configuration$region,
       onReady = configuration.onReady,
       onDisconnected = configuration.onDisconnected,
       onError = configuration.onError,
@@ -1060,8 +1070,8 @@ var CLIENT = function CLIENT() {
     this._onError({ origin: "CLIENT", message: "WebSocket not supported" });
   }
 
-  if (/wss:\/\//.test(forcewsurl)) {
-    wsurl = forcewsurl;
+  if (!wsurl) {
+    wsurl = computeWebsocketServerUrl(region);
   }
 
   // WebSocket URLs must start with wss:// or ws://localhost (the latter
@@ -1689,6 +1699,22 @@ var ping = function ping(userCallback) {
   this._sendMessage(JSON.stringify(request));
 };
 
+var computeWebsocketServerUrl = function computeWebsocketServerUrl() {
+  var region = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : undefined;
+
+  var defaultServerUrl = "wss://webrtc.apidaze.io:4062";
+
+  if (region) {
+    var regionSubdomain = REGIONS[region];
+
+    if (regionSubdomain) {
+      return "wss://webrtc." + regionSubdomain + ".apidaze.io:4062";
+    }
+  }
+
+  return defaultServerUrl;
+};
+
 exports.default = CLIENT;
 
 /***/ }),
@@ -1721,7 +1747,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
 
 
-var __VERSION__ = "3.0.0"; // webpack defineplugin variableee
+var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
@@ -2018,11 +2044,11 @@ function enumerateDevices(_ref) {
         var kind = currentDevice.kind;
 
 
-        if (audio && (kind === 'audioinput' || kind === 'audiooutput')) {
+        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
           return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
         }
 
-        if (video && kind === 'videoinput') {
+        if (video && kind === "videoinput") {
           return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
         }
 
@@ -2043,16 +2069,31 @@ function enumerateAudioDevices() {
   return enumerateDevices({ audio: true });
 }
 
+/**
+ * Sets the ID of the audio device to use for output on the given mediaElement
+ *
+ * @param {HTMLMediaElement} mediaElement - Media element to set an audio output device for
+ * @param {string} sinkId - The MediaDeviceInfo.deviceId of the audio output device.
+ *
+ * @return {Promise}
+ */
 function attachSinkId(mediaElement, sinkId) {
   return new Promise(function (resolve, reject) {
-    if (typeof mediaElement.sinkId !== 'undefined') {
+    if (typeof mediaElement.sinkId !== "undefined") {
       mediaElement.setSinkId(sinkId).then(resolve).catch(reject);
     } else {
-      reject('The browser does not support output device selection.');
+      reject("The browser does not support output device selection.");
     }
   });
 }
 
+/**
+ * Sets the ID of the audio device to use for input in the bounded call
+ *
+ * @param {string} deviceId - The MediaDeviceInfo.deviceId of the audio input device.
+ *
+ * @return {Promise}
+ */
 function setAudioInputDevice(deviceId) {
   var _this2 = this;
 
@@ -2068,7 +2109,7 @@ function setAudioInputDevice(deviceId) {
       var newAudioTrack = audioTracks[0];
 
       var audioSender = _this2.peerConnection.getSenders().find(function (sender) {
-        return sender.track.kind === 'audio';
+        return sender.track.kind === "audio";
       });
 
       audioSender.replaceTrack(newAudioTrack).then(resolve).catch(reject);
@@ -2076,6 +2117,14 @@ function setAudioInputDevice(deviceId) {
   });
 }
 
+/**
+ * Sets the ID of the video device to use for input in the bounded call
+ *
+ * @param {string} deviceId - The MediaDeviceInfo.deviceId of the video input device.
+ *
+ * @return {Promise}
+ */
+// eslint-disable-next-line no-unused-vars
 function setVideoInputDevice(deviceId) {
   var _this3 = this;
 
@@ -2091,7 +2140,7 @@ function setVideoInputDevice(deviceId) {
       var newVideoTrack = videoTracks[0];
 
       var videoSender = _this3.peerConnection.getSenders().find(function (sender) {
-        return sender.track.kind === 'Video';
+        return sender.track.kind === "video";
       });
 
       videoSender.replaceTrack(newVideoTrack).then(resolve).catch(reject);
@@ -2099,6 +2148,13 @@ function setVideoInputDevice(deviceId) {
   });
 }
 
+/**
+ * Sets the ID of the audio device to use for output in the bounded call
+ *
+ * @param {string} device - The MediaDeviceInfo.deviceId of the audio output device.
+ *
+ * @return {Promise}
+ */
 function setAudioOutputDevice(deviceId) {
   return attachSinkId(this.remoteAudioVideo, deviceId);
 }
@@ -2375,9 +2431,9 @@ function setRemoteDescription(sdp) {
     type: "answer",
     sdp: sdp
   }, function () {
-    console.log("ok");
+    _Logger2.default.log("ok");
   }, function (error) {
-    console.log("err");
+    _Logger2.default.log("err", error);
   }));
 }
 

--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -1718,9 +1718,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-var __VERSION__ = "3.0.0"; // webpack defineplugin variable
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
 
-// eslint-disable-next-line no-unused-vars
+
+var __VERSION__ = "3.0.0"; // webpack defineplugin variableee
+
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
@@ -1847,6 +1849,10 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.startLocalAudio = startLocalAudio;
   this.stopLocalVideo = stopLocalVideo;
   this.startLocalVideo = startLocalVideo;
+  this.enumerateDevices = enumerateDevices;
+  this.enumerateAudioDevices = enumerateAudioDevices;
+  this.setAudioInputDevice = setAudioInputDevice;
+  this.setAudioOutputDevice = setAudioOutputDevice;
 
   if (this.clientObj._websocket.readyState !== this.clientObj._websocket.OPEN) {
     throw { message: "WebSocket is closed" };
@@ -1990,6 +1996,112 @@ var Call = function Call(clientObj, callID, params, listeners) {
     });
   }
 };
+
+/**
+ * Get the media devices
+ *
+ * @param {Object} options - Options to indicate what kind of devices should be returned
+ * @param {Boolean} [options.audio] - Indicates if audio devices should be included
+ * @param {Boolean} [options.video] - Indicates if video devices should be included
+ *
+ * @return {Promise} Promise object to provide media devices
+ */
+function enumerateDevices(_ref) {
+  var _ref$audio = _ref.audio,
+      audio = _ref$audio === undefined ? true : _ref$audio,
+      _ref$video = _ref.video,
+      video = _ref$video === undefined ? false : _ref$video;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.enumerateDevices().then(function (devices) {
+      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
+        var kind = currentDevice.kind;
+
+
+        if (audio && (kind === 'audioinput' || kind === 'audiooutput')) {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        if (video && kind === 'videoinput') {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        return reducedDevices;
+      }, []);
+
+      resolve(filteredDevices);
+    }).catch(reject);
+  });
+}
+
+/**
+ * Get the audio devices
+ *
+ * @return {Promise} Promise object to provide audio media devices
+ */
+function enumerateAudioDevices() {
+  return enumerateDevices({ audio: true });
+}
+
+function attachSinkId(mediaElement, sinkId) {
+  return new Promise(function (resolve, reject) {
+    if (typeof mediaElement.sinkId !== 'undefined') {
+      mediaElement.setSinkId(sinkId).then(resolve).catch(reject);
+    } else {
+      reject('The browser does not support output device selection.');
+    }
+  });
+}
+
+function setAudioInputDevice(deviceId) {
+  var _this2 = this;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.getUserMedia({
+      audio: {
+        deviceId: {
+          exact: deviceId
+        }
+      }
+    }).then(function (stream) {
+      var audioTracks = stream.getAudioTracks();
+      var newAudioTrack = audioTracks[0];
+
+      var audioSender = _this2.peerConnection.getSenders().find(function (sender) {
+        return sender.track.kind === 'audio';
+      });
+
+      audioSender.replaceTrack(newAudioTrack).then(resolve).catch(reject);
+    }).catch(reject);
+  });
+}
+
+function setVideoInputDevice(deviceId) {
+  var _this3 = this;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.getUserMedia({
+      video: {
+        deviceId: {
+          exact: deviceId
+        }
+      }
+    }).then(function (stream) {
+      var videoTracks = stream.getVideoTracks();
+      var newVideoTrack = videoTracks[0];
+
+      var videoSender = _this3.peerConnection.getSenders().find(function (sender) {
+        return sender.track.kind === 'Video';
+      });
+
+      videoSender.replaceTrack(newVideoTrack).then(resolve).catch(reject);
+    }).catch(reject);
+  });
+}
+
+function setAudioOutputDevice(deviceId) {
+  return attachSinkId(this.remoteAudioVideo, deviceId);
+}
 
 function stopLocalAudio() {
   this.localAudioVideoStream.getAudioTracks().forEach(function (track) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,12 @@
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -511,6 +517,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -536,6 +548,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "aws-sign2": {
@@ -1667,6 +1685,73 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
@@ -1897,6 +1982,31 @@
       "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
       "dev": true
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "cachedir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.3.0.tgz",
@@ -2054,6 +2164,35 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "clean-css": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.8.tgz",
@@ -2156,6 +2295,16 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2196,6 +2345,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "compressible": {
@@ -2301,6 +2456,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-js": {
@@ -2774,6 +2935,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2794,6 +2961,59 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "del": {
       "version": "3.0.0",
@@ -2843,6 +3063,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-indent": {
@@ -3643,6 +3869,15 @@
         "fill-range": "^2.1.0"
       }
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "express": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
@@ -3692,6 +3927,27 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "external-editor": {
       "version": "3.0.3",
@@ -3859,6 +4115,309 @@
         "locate-path": "^2.0.0"
       }
     },
+    "findup-sync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -3938,6 +4497,15 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
       "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
       "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fresh": {
       "version": "0.5.0",
@@ -5050,6 +5618,12 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "getos": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.0.tgz",
@@ -5139,6 +5713,56 @@
         "ini": "^1.3.4"
       }
     },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      },
+      "dependencies": {
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      }
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -5216,6 +5840,66 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "hash-base": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -5278,6 +5962,15 @@
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -5517,6 +6210,64 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-local": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5681,6 +6432,15 @@
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
       "dev": true
     },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5718,6 +6478,34 @@
       "dev": true,
       "requires": {
         "ci-info": "^1.5.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
     },
     "is-dotfile": {
@@ -5817,6 +6605,23 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -5851,6 +6656,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
@@ -6425,11 +7236,26 @@
         "pify": "^2.3.0"
       }
     },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6661,6 +7487,27 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -6761,6 +7608,45 @@
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true,
       "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -6912,6 +7798,45 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -6920,6 +7845,23 @@
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "obuf": {
@@ -7109,6 +8051,12 @@
       "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
       "dev": true
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -7167,6 +8115,12 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
     "parse5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
@@ -7180,6 +8134,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-browserify": {
@@ -7318,6 +8278,12 @@
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -7595,6 +8561,16 @@
         "is-primitive": "^2.0.0"
       }
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -7805,10 +8781,56 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "dependencies": {
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        }
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
@@ -7820,6 +8842,12 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
@@ -7881,6 +8909,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -7980,6 +9017,29 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -8111,6 +9171,114 @@
         }
       }
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      }
+    },
     "sntp": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
@@ -8167,6 +9335,19 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
@@ -8175,6 +9356,12 @@
       "requires": {
         "source-map": "^0.5.6"
       }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -8226,6 +9413,15 @@
         "wbuf": "^1.7.2"
       }
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8246,6 +9442,27 @@
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
       }
     },
     "statuses": {
@@ -8537,6 +9754,48 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        }
+      }
+    },
     "toposort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",
@@ -8665,6 +9924,18 @@
       "dev": true,
       "optional": true
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -8676,6 +9947,52 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -8699,6 +10016,12 @@
           "dev": true
         }
       }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",
@@ -8735,6 +10058,12 @@
           "dev": true
         }
       }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",
@@ -8775,6 +10104,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -8903,6 +10238,306 @@
             "source-map": "^0.5.6",
             "uglify-js": "^2.8.29",
             "webpack-sources": "^1.0.1"
+          }
+        }
+      }
+    },
+    "webpack-cli": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
+      "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.1.1",
+        "findup-sync": "^3.0.0",
+        "global-modules": "^2.0.0",
+        "import-local": "^2.0.0",
+        "interpret": "^1.4.0",
+        "loader-utils": "^1.4.0",
+        "supports-color": "^6.1.0",
+        "v8-compile-cache": "^2.1.1",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/APIdaze.js",
   "scripts": {
     "build:dev": "npm run clean && rimraf ./dist && webpack --config webpack.config.dev.js && (cd dist && ln -s APIdaze-$npm_package_version-dev.js APIdaze-latest-dev.js) && (cd samples && ln -s ../dist)",
-    "build:npm": "rimraf ./lib/APIdaze.js && webpack --config webpack.config.npm.js --define process.env.NODE_ENV=\"production\"",
+    "build:npm": "webpack --config webpack.config.npm.js --define process.env.NODE_ENV=\"production\"",
     "build:prod": "rimraf ./dist && webpack --config webpack.config.prod.js --define process.env.NODE_ENV=\"production\"",
     "clean": "rimraf ./dist && rimraf samples/dist",
     "cypress": "cypress open",
@@ -52,6 +52,7 @@
     "rimraf": "^2.6.2",
     "should": "^13.2.3",
     "webpack": "^3.4.1",
+    "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^2.6.1",
     "webrtc-adapter": "6.0.4"
   }

--- a/samples/apikey_check/console.html
+++ b/samples/apikey_check/console.html
@@ -14,11 +14,9 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     alert("Success !");

--- a/samples/apikey_check/index.html
+++ b/samples/apikey_check/index.html
@@ -39,7 +39,6 @@
         console.log("Checking...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             alert("Success !");

--- a/samples/apikey_check_and_login/console.html
+++ b/samples/apikey_check_and_login/console.html
@@ -14,12 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var userid = "johndoe";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   userKeys: {
     command: "auth",

--- a/samples/apikey_check_and_login/index.html
+++ b/samples/apikey_check_and_login/index.html
@@ -68,7 +68,6 @@
 
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           userKeys: {
             command: "auth",

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -145,7 +145,6 @@
 
           APIdazeClientObj = new APIdaze.CLIENT({
             apiKey: apikeyTextObj.value,
-            wsurl: "wss://fs-de-fra-2.apidaze.io:8082",
             debug: true,
             onReady: function(sessionObj) {
               joinRoomButtonObj.disabled = false;

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -111,6 +111,12 @@
       var conferenceCall = null;
 
       function gotDevices(deviceInfos) {
+        selectors.forEach(select => {
+          while (select.firstChild) {
+            select.removeChild(select.firstChild);
+          }
+        });
+
         for (const deviceInfo of deviceInfos) {
           const option = document.createElement('option');
           option.value = deviceInfo.deviceId;
@@ -127,7 +133,10 @@
 
       function changeAudioDestination(event) {
         const audioDestination = event.target.value;
-        conferenceCall.setAudioOutputDevice(audioDestination);
+
+        if (conferenceCall) {
+          conferenceCall.setAudioOutputDevice(audioDestination);
+        }
       }
 
       audioOutputSelect.onchange = changeAudioDestination;
@@ -136,7 +145,9 @@
       audioInputSelect.onchange = function (event) {
         const audioInputDeviceId = event.target.value;
 
-        conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        if (conferenceCall) {
+          conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        }
       };
 
       checkButtonObj.onclick = function() {
@@ -148,6 +159,13 @@
             debug: true,
             onReady: function(sessionObj) {
               joinRoomButtonObj.disabled = false;
+
+              // populate user media devices
+              APIdazeClientObj
+                .enumerateAudioDevices()
+                .then(gotDevices);
+
+              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             },
             onError: function(errorMessage){
               alert("Got error : " + errorMessage);
@@ -163,6 +181,8 @@
           {
             command: "joinRoom",
             userName: "guest",
+            audioInputDeviceId: audioInputSelect.value,
+            audioOutputDeviceId: audioOutputSelect.value,
           },
           {
             onRoomMembersInitialList: function(members) {
@@ -183,14 +203,6 @@
               console.log('I left the room');
               joinRoomButtonObj.disabled = false;
               leaveRoomButtonObj.disabled = true;
-            },
-            onAnswer: function() {
-              // populate user media devices
-              conferenceCall
-                .enumerateAudioDevices()
-                .then(gotDevices);
-
-              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             }
           }
         );

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -3,187 +3,208 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>Sample App</title>
+
+    <style>
+      .hidden {
+        display: none !important;
+      }
+    </style>
   </head>
   <body>
     <div id='root'>
-      <h1>Connect to conference room, in audio/video</h1>
-      <h3>
-        This example shows how to connect to an audio/video conference room. Check your JavaScript console while testing to see what's happening in the background !
-      </h3>
-      <p>
-        The first step is to join the conference room in audio, then the JavaScript
-        object that manages the conference room can be used to "upgrade" to a video
-        enabled conference room.
-      </p>
-      <p>
-      Join a conference room in audio mode : <code>CLIENT.call(callDetailsObject, callbackObject)</code>.
-      This JavaScript call will trigger your <code>External Script</code> (and
-      pass the <code>callDetailsObject</code> as URL parameters), that must
-      return an XML string instructing APIdaze to start a conference room
-      (the name of the conference is managed from the <code>External Script</code>):
-      </p>
-      <p>
-        <code>callDetailsObject</code>
-        <pre>
-        {
-          command : "JoinRoom", // optional
-          userName : "guest",   // optional
-        }
-        </pre>
-      </p>
-      <p>
-        <code>callbackObject</code> Contains a list of functions that execute when conference events are triggered (join/leeave events, initial members list, etc.) :
-        <pre>
-        {
-          onRoomMembersInitialList: function(members) {
-            console.log('Got members for this room : ' + JSON.stringify(members));
-          },
-          onRoomAdd: function(member) {
-            console.log('New member joined room : ' + JSON.stringify(member));
-          },
-          onRoomDel: function(member) {
-            console.log('Member left room : ' + JSON.stringify(member));
-          },
-          onRoomTalking: function(member) {
-            console.log('Start/stop talking event from a member : ' + JSON.stringify(member));
-          },
-          onHangup: function(){
-            console.log('I left the room');
-          }
-        }
-        </pre>
-      </p>
-      <p>
-        <code>XML return from External Script</code>
-        <pre>
-        &lt;document&gt;
-          &lt;work&gt;
-            &lt;answer /&gt;
-            &lt;wait&gt;1&lt;/wait&gt;
-            &lt;speak&gt;Welcome, you are joining the conference.&lt;/speak&gt;
-            &lt;conference&gt;test&lt;/conference&gt;
-            &lt;hangup /&gt;
-          &lt;/work&gt;
-        &lt;/document&gt;
-        </pre>
-      </p>
       <div>
+        <h1>Connect to conference room, in audio</h1>
+        <h3>
+          This example shows how to connect to an audio conference room. Check your JavaScript console while testing to see what's happening in the background !
+        </h3>
+        <p>
+        Join a conference room in audio mode : <code>CLIENT.call(callDetailsObject, callbackObject)</code>.
+        This JavaScript call will trigger your <code>External Script</code> (and
+        pass the <code>callDetailsObject</code> as URL parameters), that must
+        return an XML string instructing APIdaze to start a conference room
+        (the name of the conference is managed from the <code>External Script</code>):
+        </p>
+        <p>
+          <code>callDetailsObject</code>
+          <pre>
+          {
+            command : "JoinRoom", // optional
+            userName : "guest",   // optional
+          }
+          </pre>
+        </p>
+        <p>
+          <code>callbackObject</code> Contains a list of functions that execute when conference events are triggered (join/leeave events, initial members list, etc.) :
+          <pre>
+          {
+            onRoomMembersInitialList: function(members) {
+              console.log('Got members for this room : ' + JSON.stringify(members));
+            },
+            onRoomAdd: function(member) {
+              console.log('New member joined room : ' + JSON.stringify(member));
+            },
+            onRoomDel: function(member) {
+              console.log('Member left room : ' + JSON.stringify(member));
+            },
+            onRoomTalking: function(member) {
+              console.log('Start/stop talking event from a member : ' + JSON.stringify(member));
+            },
+            onHangup: function(){
+              console.log('I left the room');
+            }
+          }
+          </pre>
+        </p>
+        <p>
+          <code>XML return from External Script</code>
+          <pre>
+          &lt;document&gt;
+            &lt;work&gt;
+              &lt;answer /&gt;
+              &lt;wait&gt;1&lt;/wait&gt;
+              &lt;speak&gt;Welcome, you are joining the conference.&lt;/speak&gt;
+              &lt;conference&gt;test&lt;/conference&gt;
+              &lt;hangup /&gt;
+            &lt;/work&gt;
+          &lt;/document&gt;
+          </pre>
+        </p>
+      </div>
+      <div style="margin-bottom: 5px;">
         <span>API key : </span>
         <input id="apikeyTextId" type="text" value="" placeholder="e.g. : 23dh4r56">
         <input id="checkButtonId" type="button" value="Connect">
       </div>
       <div>
-        <input id="joinRoomButtonId" type="button" disabled="true" style="width: 90px" value="Call" class="kick_button btn btn-default" />
-        <input id="startVideoInRoomButtonId" type="button" disabled="true" style="width: 90px" value="Start Video" class="btn btn-default" />
-        <input id="leaveRoomButtonId" type="button" disabled="true" style="width: 90px" value="Hangup" class="btn btn-default" />
+        <input id="joinRoomButtonId" type="button" disabled="true" style="width: 90px" value="Join Room" class="kick_button btn btn-default" />
+        <input id="leaveRoomButtonId" type="button" disabled="true" style="width: 90px" value="Leave Room" class="btn btn-default" />
+      </div>
+      <div id="mediaDevices" class="hidden">
+        <br>
+        <div class="select">
+          <label for="audioSource">Audio input source: </label>
+          <select id="audioSource"></select>
+        </div>
+
+        <div class="select">
+          <label for="audioOutput">Audio output destination: </label>
+          <select id="audioOutput"></select>
+        </div>
+
+        <p>
+          <strong>Note:</strong> The actual input and output devices are displayed if the permissions are given to retrieve media devices. (may require reloading the page)
+        </p>
       </div>
     </div>
-  <script type="text/javascript" src="https://api4.apidaze.io/javascript/releases/APIdaze-latest-dev-master.js"></script></body>
-  <script>
-    const apikeyTextObj = document.getElementById('apikeyTextId');
-    const checkButtonObj = document.getElementById('checkButtonId');
-    const joinRoomButtonObj = document.getElementById('joinRoomButtonId');
-    const startVideoInRoomButtonObj = document.getElementById('startVideoInRoomButtonId');
-    const leaveRoomButtonObj = document.getElementById('leaveRoomButtonId');
 
-    var APIdazeClientObj = null;
-    var conferenceCall = null;
+    <script type="text/javascript" src="/lib/APIdaze.js"></script>
+    <script>
+      const apikeyTextObj = document.getElementById('apikeyTextId');
+      const checkButtonObj = document.getElementById('checkButtonId');
+      const joinRoomButtonObj = document.getElementById('joinRoomButtonId');
+      const leaveRoomButtonObj = document.getElementById('leaveRoomButtonId');
+      const audioInputSelect = document.querySelector('select#audioSource');
+      const audioOutputSelect = document.querySelector('select#audioOutput');
+      const selectors = [audioInputSelect, audioOutputSelect];
 
-    checkButtonObj.onclick = function() {
-      if (/^[a-zA-Z0-9]{8}$/.test(apikeyTextObj.value)) {
-        console.log("Checking...");
+      var APIdazeClientObj = null;
+      var conferenceCall = null;
 
-        APIdazeClientObj = new APIdaze.CLIENT({
-          apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-de-fra-2.apidaze.io:8082",
-          debug: true,
-          onReady: function(sessionObj) {
-            joinRoomButtonObj.disabled = false;
-          },
-          onError: function(errorMessage){
-            alert("Got error : " + errorMessage);
+      function gotDevices(deviceInfos) {
+        for (const deviceInfo of deviceInfos) {
+          const option = document.createElement('option');
+          option.value = deviceInfo.deviceId;
+
+          if (deviceInfo.kind === 'audioinput') {
+            option.text = deviceInfo.label || `microphone ${audioInputSelect.length + 1}`;
+            audioInputSelect.appendChild(option);
+          } else if (deviceInfo.kind === 'audiooutput') {
+            option.text = deviceInfo.label || `speaker ${audioOutputSelect.length + 1}`;
+            audioOutputSelect.appendChild(option);
           }
-        });
-      } else {
-        alert("Wrong API key or illegal character in User name");
+        }
       }
-    }
 
-    joinRoomButtonObj.onclick = function(){
-      joinRoomButtonObj.disabled = true;
-      conferenceCall = APIdazeClientObj.call(
-        {
-          command: "joinRoom",
-          userName: "guest",
-        },
-        {
-          onRoomMembersInitialList: function(members) {
-            console.log('Got members for this room : ' + JSON.stringify(members));
-            joinRoomButtonObj.disabled = true;
-            leaveRoomButtonObj.disabled = false;
-            startVideoInRoomButtonObj.disabled = false;
+      function changeAudioDestination(event) {
+        const audioDestination = event.target.value;
+        conferenceCall.setAudioOutputDevice(audioDestination);
+      }
+
+      audioOutputSelect.onchange = changeAudioDestination;
+      audioOutputSelect.disabled = !('sinkId' in HTMLMediaElement.prototype);
+
+      audioInputSelect.onchange = function (event) {
+        const audioInputDeviceId = event.target.value;
+
+        conferenceCall.setAudioInputDevice(audioInputDeviceId);
+      };
+
+      checkButtonObj.onclick = function() {
+        if (/^[a-zA-Z0-9]{8}$/.test(apikeyTextObj.value)) {
+          console.log("Checking...");
+
+          APIdazeClientObj = new APIdaze.CLIENT({
+            apiKey: apikeyTextObj.value,
+            wsurl: "wss://fs-de-fra-2.apidaze.io:8082",
+            debug: true,
+            onReady: function(sessionObj) {
+              joinRoomButtonObj.disabled = false;
+            },
+            onError: function(errorMessage){
+              alert("Got error : " + errorMessage);
+            }
+          });
+        } else {
+          alert("Wrong API key or illegal character in User name");
+        }
+      }
+
+      joinRoomButtonObj.onclick = function(){
+        conferenceCall = APIdazeClientObj.call(
+          {
+            command: "joinRoom",
+            userName: "guest",
           },
-          onRoomAdd: function(member) {
-            console.log('New member joined room : ' + JSON.stringify(member));
-          },
-          onRoomDel: function(member) {
-            console.log('Member left room : ' + JSON.stringify(member));
-          },
-          onRoomTalking: function(member) {
-            console.log('Start/stop talking event from a member : ' + JSON.stringify(member));
-          },
-          onHangup: function(){
-            console.log('I left the room');
-            joinRoomButtonObj.disabled = false;
-            leaveRoomButtonObj.disabled = true;
-            startVideoInRoomButtonObj.disabled = true;
+          {
+            onRoomMembersInitialList: function(members) {
+              console.log('Got members for this room : ' + JSON.stringify(members));
+              joinRoomButtonObj.disabled = true;
+              leaveRoomButtonObj.disabled = false;
+            },
+            onRoomAdd: function(member) {
+              console.log('New member joined room : ' + JSON.stringify(member));
+            },
+            onRoomDel: function(member) {
+              console.log('Member left room : ' + JSON.stringify(member));
+            },
+            onRoomTalking: function(member) {
+              console.log('Start/stop talking event from a member : ' + JSON.stringify(member));
+            },
+            onHangup: function(){
+              console.log('I left the room');
+              joinRoomButtonObj.disabled = false;
+              leaveRoomButtonObj.disabled = true;
+            },
+            onAnswer: function() {
+              // populate user media devices
+              conferenceCall
+                .enumerateAudioDevices()
+                .then(gotDevices);
+
+              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
+            }
           }
-        });
-    }
+        );
+      }
 
-    const startVideo = function(){
-      startVideoInRoomButtonObj.disabled = true;
-      startVideoInRoomButtonObj.setAttribute('value', '...');
+      leaveRoomButtonObj.onclick = function() {
+        leaveRoomButtonObj.disabled = true;
+        joinRoomButtonObj.disabled = false;
 
-      conferenceCall.initVideoInConferenceRoom({
-        localVideoContainerId: 'myVideoContainerId', // Optional, not used here
-        remoteVideosContainerId: 'remoteVideosContainerId' // Optional, not used here
-      },
-        function() {
-          console.log('We joined the room, now publish our video stream there');
-          conferenceCall.publishMyVideoInRoom();
+        conferenceCall.hangup();
+        conferenceCall = null;
+      }
 
-          startVideoInRoomButtonObj.disabled = false;
-          startVideoInRoomButtonObj.setAttribute('value', 'Detach Video');
-          startVideoInRoomButtonObj.onclick = detachVideo;
-        },
-        function(err) {
-          console.log('Failed to join room, error :', err);
-          startVideoInRoomButtonObj.disabled = false;
-          startVideoInRoomButtonObj.setAttribute('value', 'Start Video');
-        });
-    }
-
-    const detachVideo = function(){
-      startVideoInRoomButtonObj.disabled = false;
-      startVideoInRoomButtonObj.setAttribute('value', 'Start Video');
-
-      conferenceCall.detachVideo();
-
-      startVideoInRoomButtonObj.onclick = startVideo;
-    }
-
-    startVideoInRoomButtonObj.onclick = startVideo;
-
-    leaveRoomButtonObj.onclick = function() {
-      startVideoInRoomButtonObj.disabled = true;
-      leaveRoomButtonObj.disabled = true;
-      joinRoomButtonObj.disabled = false;
-
-      conferenceCall.detachVideo();
-      conferenceCall.hangup();
-      conferenceCall = null;
-    }
-
-  </script>
+    </script>
+  </body>
 </html>

--- a/samples/receive_text/console.html
+++ b/samples/receive_text/console.html
@@ -14,13 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var ws_server = "fs-us-ny-1.apidaze.io:8082";
-var wsurl = "wss://" + ws_server;
 var userid = "johndoe";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   userKeys: {
     command: "auth",
@@ -29,7 +26,7 @@ var APIdazeClientObj = new APIdaze.CLIENT({
   onReady: function() {
     console.log("Logged in !");
     console.log("You may now just run the following cURL command to receive text here");
-    console.log("curl -X POST 'https://api4.apidaze.io/" + apiKey + "/chat/send' --data 'api_secret=YOURAPISECRET&from=me&to=" + userid + "&ws_server=" + ws_server + "&text=Hello'")
+    console.log("curl -X POST 'https://api4.apidaze.io/" + apiKey + "/chat/send' --data 'api_secret=YOURAPISECRET&from=me&to=" + userid + "&ws_server=" + APIdazeClientObj._wsUrl + "&text=Hello'")
   },
   onExternalMessageReceived(messageObj) {
     console.log("Received", JSON.stringify(messageObj));

--- a/samples/receive_text/index.html
+++ b/samples/receive_text/index.html
@@ -65,7 +65,6 @@
 
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           userKeys: userKeys,
           onReady: function(sessionObj) {

--- a/samples/rtt_to_server/console.html
+++ b/samples/rtt_to_server/console.html
@@ -14,7 +14,6 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var rttInterval = null;
 
 var stopRTT = function() {
@@ -41,7 +40,6 @@ var startRTT = function() {
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     startRTT();

--- a/samples/rtt_to_server/index.html
+++ b/samples/rtt_to_server/index.html
@@ -51,7 +51,6 @@
         console.log("Connecting...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             alert("Success !");

--- a/samples/send_text/console.html
+++ b/samples/send_text/console.html
@@ -14,12 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var text = "Hello there";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     APIdazeClientObj.sendText({

--- a/samples/send_text/index.html
+++ b/samples/send_text/index.html
@@ -73,7 +73,6 @@
         console.log("Checking...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             APIdazeClientObj.sendText({

--- a/src/CLIENT.js
+++ b/src/CLIENT.js
@@ -8,12 +8,20 @@ var STATUS_READY = 2;
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT |";
 var LOGGER = new Logger(false, LOG_PREFIX);
 
+const REGIONS = {
+  "us-east": "us1",
+  "us-west": "us2",
+  "eu-central": "eu1",
+  "eu-west": "eu2",
+  "ap-southeast": "ap1"
+};
+
 var CLIENT = function(configuration = {}) {
   let {
     apiKey,
-    wsurl,
-    forcewsurl,
+    wsurl = undefined,
     sessid = null,
+    region = undefined,
     onReady,
     onDisconnected,
     onError,
@@ -80,8 +88,8 @@ var CLIENT = function(configuration = {}) {
     this._onError({ origin: "CLIENT", message: "WebSocket not supported" });
   }
 
-  if (/wss:\/\//.test(forcewsurl)) {
-    wsurl = forcewsurl;
+  if (!wsurl) {
+    wsurl = computeWebsocketServerUrl(region);
   }
 
   // WebSocket URLs must start with wss:// or ws://localhost (the latter
@@ -723,6 +731,20 @@ const ping = function(userCallback) {
   };
 
   this._sendMessage(JSON.stringify(request));
+};
+
+const computeWebsocketServerUrl = function(region = undefined) {
+  const defaultServerUrl = "wss://webrtc.apidaze.io:4062";
+
+  if (region) {
+    const regionSubdomain = REGIONS[region];
+
+    if (regionSubdomain) {
+      return `wss://webrtc.${regionSubdomain}.apidaze.io:4062`;
+    }
+  }
+
+  return defaultServerUrl;
 };
 
 export default CLIENT;

--- a/src/Call.js
+++ b/src/Call.js
@@ -27,11 +27,11 @@ var Call = function(clientObj, callID, params, listeners) {
   var {
     activateAudio = true,
     tagId = "apidaze-audio-video-container-id-" + randomString,
-    audioParams = {},
+    audioParams = {}
   } = params;
 
   const videoParams = {
-    activateScreenShare: false,
+    activateScreenShare: false
   };
 
   if (videoParams.activateScreenShare === true) {
@@ -151,7 +151,7 @@ var Call = function(clientObj, callID, params, listeners) {
   }
 
   var GUMConstraints = {
-    audio: this.activateAudio,
+    audio: this.activateAudio
   };
 
   if (this.activateVideo === false) {
@@ -326,20 +326,23 @@ function enumerateDevices({ audio = true, video = false }) {
   return new Promise((resolve, reject) => {
     navigator.mediaDevices
       .enumerateDevices()
-      .then((devices) => {
-        const filteredDevices = devices.reduce((reducedDevices, currentDevice) => {
-          const { kind } = currentDevice;
+      .then(devices => {
+        const filteredDevices = devices.reduce(
+          (reducedDevices, currentDevice) => {
+            const { kind } = currentDevice;
 
-          if (audio && (kind === 'audioinput' || kind === 'audiooutput')) {
-            return [ ...reducedDevices, currentDevice ];
-          }
+            if (audio && (kind === "audioinput" || kind === "audiooutput")) {
+              return [...reducedDevices, currentDevice];
+            }
 
-          if (video && kind === 'videoinput') {
-            return [ ...reducedDevices, currentDevice ];
-          }
+            if (video && kind === "videoinput") {
+              return [...reducedDevices, currentDevice];
+            }
 
-          return reducedDevices;
-        }, []);
+            return reducedDevices;
+          },
+          []
+        );
 
         resolve(filteredDevices);
       })
@@ -366,12 +369,13 @@ function enumerateAudioDevices() {
  */
 function attachSinkId(mediaElement, sinkId) {
   return new Promise((resolve, reject) => {
-    if (typeof mediaElement.sinkId !== 'undefined') {
-      mediaElement.setSinkId(sinkId)
+    if (typeof mediaElement.sinkId !== "undefined") {
+      mediaElement
+        .setSinkId(sinkId)
         .then(resolve)
         .catch(reject);
     } else {
-      reject('The browser does not support output device selection.');
+      reject("The browser does not support output device selection.");
     }
   });
 }
@@ -393,13 +397,13 @@ function setAudioInputDevice(deviceId) {
           }
         }
       })
-      .then((stream) => {
+      .then(stream => {
         const audioTracks = stream.getAudioTracks();
         const newAudioTrack = audioTracks[0];
 
         const audioSender = this.peerConnection
           .getSenders()
-          .find((sender) => sender.track.kind === 'audio');
+          .find(sender => sender.track.kind === "audio");
 
         audioSender
           .replaceTrack(newAudioTrack)
@@ -428,13 +432,13 @@ function setVideoInputDevice(deviceId) {
           }
         }
       })
-      .then((stream) => {
+      .then(stream => {
         const videoTracks = stream.getVideoTracks();
         const newVideoTrack = videoTracks[0];
 
         const videoSender = this.peerConnection
           .getSenders()
-          .find((sender) => sender.track.kind === 'Video');
+          .find(sender => sender.track.kind === "video");
 
         videoSender
           .replaceTrack(newVideoTrack)

--- a/tests/CLIENT.test.js
+++ b/tests/CLIENT.test.js
@@ -3,7 +3,7 @@ var should = require('should');
 var expect = require('chai').expect;
 var path = require('path');
 
-require('./setup_ws_server.js');
+import { prepareMockWebsocketServer } from './setup_ws_server.js';
 
 import { WebSocket, Server } from 'mock-socket';
 
@@ -20,29 +20,37 @@ describe('CLIENT', function() {
         expect(error).to.eql({ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'});
       }
     });
-    it("should throw exception  {ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'}", function() {
-      try {
-        var client = new APIdaze.CLIENT({});
-      } catch(error){
-        expect(error).to.eql({ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'});
-      }
-    });
   });
-  describe('#new CLIENT({apiKey: "testapikey"}), no WebSocket URL', function() {
+
+  describe('#new CLIENT({apiKey: "testapikey"}), valid apiKey and no region preference', function() {
+    it("should have _wsUrl set with its default value", function(done) {
+      this.timeout(50000);
+      var client = new APIdaze.CLIENT({
+        apiKey: "testingIfApiKeyIsValid",
+        onReady: function(){
+          expect(client._wsUrl).to.equal("wss://webrtc.apidaze.io:4062");
+
+          client.shutdown();
+          done();
+        }
+      });
+    })
+  });
+
+  describe('#new CLIENT({apiKey: "testapikey"}), WebSocket URL with ws protocol', function() {
     it("should throw exception  {ok: false, message: 'Wrong WebSocket URL, must start with wss://', origin: 'CLIENT'}", function() {
       try {
-        var client = new APIdaze.CLIENT({apiKey: "testapikey"});
+        var client = new APIdaze.CLIENT({apiKey: "testapikey", wsurl: "ws://webrtc.apidaze.io:4062"});
       } catch(error){
         expect(error).to.eql({ok: false, message: 'Wrong WebSocket URL, must start with wss://', origin: 'CLIENT'});
       }
     });
   });
-  describe('#new CLIENT({apiKey: "apiKeyWithoutExternalScript", wsurl: "ws://localhost:9080"}), No External Script configured', function() {
+
+  describe('#new CLIENT({apiKey: "apiKeyWithoutExternalScript"}), No External Script configured', function() {
     it("should throw exception  {ok: false, message: Not allowed to login', origin: 'CLIENT'}", function(done) {
       var client = new APIdaze.CLIENT({
-        debug: true,
         apiKey: "apiKeyWithoutExternalScript",
-        wsurl: "ws://localhost:9080",
         onError: function(error){
           console.log("Error : ", error);
           expect(error).to.eql("Not allowed to login");
@@ -52,12 +60,29 @@ describe('CLIENT', function() {
       });
     });
   });
-  describe('#new CLIENT({apiKey:"apiKeyIsValid", wsurl: "ws://localhost:9080"}), valid apiKey and WebSocket URL', function() {
+
+  describe('#new CLIENT({apiKey:"apiKeyIsValid", wsurl: "wss://webrtc.apidaze.io:4062"}), valid apiKey and WebSocket URL', function() {
     it("should call onReady handler if present", function(done) {
       var client = new APIdaze.CLIENT({
-        debug: true,
         apiKey: "testingIfApiKeyIsValid",
-        wsurl: "ws://localhost:9080",
+        onReady: function(){
+          console.log("Ready");
+          client.shutdown();
+          done();
+        }
+      });
+    });
+  });
+
+  describe.only('#new CLIENT({apiKey:"apiKeyIsValid", region: "us-west"}), valid apiKey and region', function() {
+    before(() => {
+      prepareMockWebsocketServer("wss://webrtc.us2.apidaze.io:4062")
+    })
+
+    it("should call onReady handler if present", function(done) {
+      var client = new APIdaze.CLIENT({
+        apiKey: "testingIfApiKeyIsValid",
+        region: "us-west",
         onReady: function(){
           console.log("Ready");
           client.shutdown();

--- a/tests/setup_ws_server.js
+++ b/tests/setup_ws_server.js
@@ -42,8 +42,8 @@ function clientReadyResponse(sessid) {
 	}
 }
 
-before(() => {
-	const mockServer = new Server('ws://localhost:9080');
+export function prepareMockWebsocketServer(serverUrl) {
+	const mockServer = new Server(serverUrl);
 	mockServer.on('connection', (server) => {
 		console.log("[WsServer] Got connection");
 	});
@@ -60,18 +60,23 @@ before(() => {
 
 		console.log("[WsServer] received message :", JSONMessage);
 		switch (params.apiKey) {
-			case "apiKeyWithoutExternalScript":
-			console.log("[WsServer] No External Script for this apiKey");
-			mockServer.send(JSON.stringify(invalidExternalScriptResponse()))
-			return;
-			case "testingIfApiKeyIsValid":
-			console.log("[WsServer] Valid API key");
-			// API key validated
-			mockServer.send(JSON.stringify(genericPongResponse(sessid)));
-			mockServer.send('{"wsp_version":"1","id":11925,"method":"verto.clientReady","params":{"reattached_sessions":[],"id":"f28d6fc8-b96d-11e7-85cd-ebd8388b16c8","sessid":"f28d6fc8-b96d-11e7-85cd-ebd8388b16c8"}}');
-			return;
-			default:
-			console.log("[WsServer] apiKey is valid")
+			case "apiKeyWithoutExternalScript":{
+				console.log("[WsServer] No External Script for this apiKey");
+				mockServer.send(JSON.stringify(invalidExternalScriptResponse()))
+				break;
+			}
+			case "testingIfApiKeyIsValid": {
+				console.log("[WsServer] Valid API key");
+				// API key validated
+				mockServer.send(JSON.stringify(genericPongResponse(sessid)));
+				mockServer.send(JSON.stringify(clientReadyResponse(sessid)))
+				break;
+			}
+			default: {
+				console.log("[WsServer] apiKey is valid")
+			}
 		}
 	});
-})
+}
+
+before(()  => prepareMockWebsocketServer('wss://webrtc.apidaze.io:4062'));


### PR DESCRIPTION
Now, one can set a track in an ongoing call.

The new methods introduced;

- Call#enumerateDevices is a wrapper around `navigator.mediaDevices.enumerateDevices` accepting an `options` argument that is an object having two properties such as `audio` and `video`. The parameters in `options` work in a way indicating what kind of media devices should be enumerated.
- Call#enumerateAudioDevices is a convenient method enumerating the audio devices.
- Call#setAudioInputDevice is a method accepting only one argument that is the device ID that should be used for audio input.
- Call#setAudioOutputDevice is a method accepting only one argument that is the device ID that should be used for audio output.