### PR TITLE
feat: Add region support

### DIFF
--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -982,6 +982,8 @@ var _Logger2 = _interopRequireDefault(_Logger);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
 var STATUS_INIT = 1;
@@ -1013,12 +1015,17 @@ var CLIENT = function CLIENT() {
       debug = configuration.debug,
       _configuration$userKe = configuration.userKeys,
       userKeys = _configuration$userKe === undefined ? {} : _configuration$userKe,
-      iceServers = configuration.iceServers;
+      _configuration$iceSer = configuration.iceServers,
+      iceServers = _configuration$iceSer === undefined ? [{ urls: "stun:stun.l.google.com:19302" }] : _configuration$iceSer;
+
+
+  if (iceServers === null) {
+    iceServers = [];
+  }
 
   /**
    * Functions exposed to user
    */
-
   this.speedTest = speedTest.bind(this);
   this.ping = ping.bind(this);
   this.shutdown = shutdown.bind(this);
@@ -1026,6 +1033,8 @@ var CLIENT = function CLIENT() {
   this.disconnect = shutdown.bind(this); // disconnect is kept for compatibility reasons
   this.sendText = sendText.bind(this);
   this.getWebsocketServer = getWebsocketServer.bind(this);
+  this.enumerateDevices = enumerateDevices;
+  this.enumerateAudioDevices = enumerateAudioDevices;
 
   // User defined handlers
   this._onDisconnected = function () {
@@ -1715,6 +1724,52 @@ var computeWebsocketServerUrl = function computeWebsocketServerUrl() {
   return defaultServerUrl;
 };
 
+/**
+ * Get the media devices
+ *
+ * @param {Object} options - Options to indicate what kind of devices should be returned
+ * @param {Boolean} [options.audio] - Indicates if audio devices should be included
+ * @param {Boolean} [options.video] - Indicates if video devices should be included
+ *
+ * @return {Promise} Promise object to provide media devices
+ */
+function enumerateDevices(_ref2) {
+  var _ref2$audio = _ref2.audio,
+      audio = _ref2$audio === undefined ? true : _ref2$audio,
+      _ref2$video = _ref2.video,
+      video = _ref2$video === undefined ? false : _ref2$video;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.enumerateDevices().then(function (devices) {
+      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
+        var kind = currentDevice.kind;
+
+
+        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        if (video && kind === "videoinput") {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        return reducedDevices;
+      }, []);
+
+      resolve(filteredDevices);
+    }).catch(reject);
+  });
+}
+
+/**
+ * Get the audio devices
+ *
+ * @return {Promise} Promise object to provide audio media devices
+ */
+function enumerateAudioDevices() {
+  return enumerateDevices({ audio: true });
+}
+
 exports.default = CLIENT;
 
 /***/ }),
@@ -1744,11 +1799,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
-
-
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
+// eslint-disable-next-line no-unused-vars
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
@@ -1769,10 +1822,15 @@ var Call = function Call(clientObj, callID, params, listeners) {
 
   var _params$activateAudio = params.activateAudio,
       activateAudio = _params$activateAudio === undefined ? true : _params$activateAudio,
+      audioInputDeviceId = params.audioInputDeviceId,
+      audioOutputDeviceId = params.audioOutputDeviceId,
+      videoInputDeviceId = params.videoInputDeviceId,
       _params$tagId = params.tagId,
       tagId = _params$tagId === undefined ? "apidaze-audio-video-container-id-" + randomString : _params$tagId,
       _params$audioParams = params.audioParams,
-      audioParams = _params$audioParams === undefined ? {} : _params$audioParams;
+      audioParams = _params$audioParams === undefined ? {} : _params$audioParams,
+      _params$iceServers = params.iceServers,
+      iceServers = _params$iceServers === undefined ? clientObj._iceServers : _params$iceServers;
 
 
   var videoParams = {
@@ -1805,6 +1863,7 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.activateAudio = activateAudio;
   this.videoParams = videoParams;
   this.audioParams = audioParams;
+  this.iceServers = iceServers;
   this.audioVideoTagId = tagId;
 
   var audioVideoDOMContainerObj = document.getElementById(tagId);
@@ -1818,6 +1877,10 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.remoteAudioVideo.controls = false;
   if (this.activateVideo === false) {
     this.remoteAudioVideo.style.display = "none";
+  }
+
+  if (audioOutputDeviceId && typeof audioOutputDeviceId === 'string' && audioOutputDeviceId.length > 0) {
+    attachSinkId(this.remoteAudioVideo, audioOutputDeviceId);
   }
 
   if (audioVideoDOMContainerObj == null) {
@@ -1875,8 +1938,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.startLocalAudio = startLocalAudio;
   this.stopLocalVideo = stopLocalVideo;
   this.startLocalVideo = startLocalVideo;
-  this.enumerateDevices = enumerateDevices;
-  this.enumerateAudioDevices = enumerateAudioDevices;
   this.setAudioInputDevice = setAudioInputDevice;
   this.setAudioOutputDevice = setAudioOutputDevice;
 
@@ -1888,8 +1949,22 @@ var Call = function Call(clientObj, callID, params, listeners) {
     audio: this.activateAudio
   };
 
+  if (this.activateAudio && audioInputDeviceId && typeof audioInputDeviceId === 'string' && audioInputDeviceId.length > 0) {
+    GUMConstraints.audio = {
+      deviceId: {
+        exact: audioInputDeviceId
+      }
+    };
+  }
+
   if (this.activateVideo === false) {
     GUMConstraints.video = false;
+  } else if (videoInputDeviceId && typeof videoInputDeviceId === 'string' && videoInputDeviceId.length > 0) {
+    GUMConstraints.video = {
+      deviceId: {
+        exact: videoInputDeviceId
+      }
+    };
   } else {
     LOGGER.log("Need to set GUMConstraints.video");
     GUMConstraints.video = {
@@ -2022,52 +2097,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
     });
   }
 };
-
-/**
- * Get the media devices
- *
- * @param {Object} options - Options to indicate what kind of devices should be returned
- * @param {Boolean} [options.audio] - Indicates if audio devices should be included
- * @param {Boolean} [options.video] - Indicates if video devices should be included
- *
- * @return {Promise} Promise object to provide media devices
- */
-function enumerateDevices(_ref) {
-  var _ref$audio = _ref.audio,
-      audio = _ref$audio === undefined ? true : _ref$audio,
-      _ref$video = _ref.video,
-      video = _ref$video === undefined ? false : _ref$video;
-
-  return new Promise(function (resolve, reject) {
-    navigator.mediaDevices.enumerateDevices().then(function (devices) {
-      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
-        var kind = currentDevice.kind;
-
-
-        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        if (video && kind === "videoinput") {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        return reducedDevices;
-      }, []);
-
-      resolve(filteredDevices);
-    }).catch(reject);
-  });
-}
-
-/**
- * Get the audio devices
- *
- * @return {Promise} Promise object to provide audio media devices
- */
-function enumerateAudioDevices() {
-  return enumerateDevices({ audio: true });
-}
 
 /**
  * Sets the ID of the audio device to use for output on the given mediaElement
@@ -2453,7 +2482,7 @@ function attachStreamToPeerConnection() {
  * function.
  */
 function createPeerConnection() {
-  var pc_config = { iceServers: [{ urls: "stun:stun.l.google.com:19302" }] };
+  var pc_config = { iceServers: this.iceServers };
   var pc_constraints = {
     optional: [{ DtlsSrtpKeyAgreement: true }, { googIPv6: false }],
     mandatory: {

--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -989,13 +989,23 @@ var STATUS_READY = 2;
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
+var REGIONS = {
+  "us-east": "us1",
+  "us-west": "us2",
+  "eu-central": "eu1",
+  "eu-west": "eu2",
+  "ap-southeast": "ap1"
+};
+
 var CLIENT = function CLIENT() {
   var configuration = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var apiKey = configuration.apiKey,
-      wsurl = configuration.wsurl,
-      forcewsurl = configuration.forcewsurl,
+      _configuration$wsurl = configuration.wsurl,
+      wsurl = _configuration$wsurl === undefined ? undefined : _configuration$wsurl,
       _configuration$sessid = configuration.sessid,
       sessid = _configuration$sessid === undefined ? null : _configuration$sessid,
+      _configuration$region = configuration.region,
+      region = _configuration$region === undefined ? undefined : _configuration$region,
       onReady = configuration.onReady,
       onDisconnected = configuration.onDisconnected,
       onError = configuration.onError,
@@ -1060,8 +1070,8 @@ var CLIENT = function CLIENT() {
     this._onError({ origin: "CLIENT", message: "WebSocket not supported" });
   }
 
-  if (/wss:\/\//.test(forcewsurl)) {
-    wsurl = forcewsurl;
+  if (!wsurl) {
+    wsurl = computeWebsocketServerUrl(region);
   }
 
   // WebSocket URLs must start with wss:// or ws://localhost (the latter
@@ -1689,6 +1699,22 @@ var ping = function ping(userCallback) {
   this._sendMessage(JSON.stringify(request));
 };
 
+var computeWebsocketServerUrl = function computeWebsocketServerUrl() {
+  var region = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : undefined;
+
+  var defaultServerUrl = "wss://webrtc.apidaze.io:4062";
+
+  if (region) {
+    var regionSubdomain = REGIONS[region];
+
+    if (regionSubdomain) {
+      return "wss://webrtc." + regionSubdomain + ".apidaze.io:4062";
+    }
+  }
+
+  return defaultServerUrl;
+};
+
 exports.default = CLIENT;
 
 /***/ }),
@@ -1721,7 +1747,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
 
 
-var __VERSION__ = "3.0.0"; // webpack defineplugin variableee
+var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
@@ -2018,11 +2044,11 @@ function enumerateDevices(_ref) {
         var kind = currentDevice.kind;
 
 
-        if (audio && (kind === 'audioinput' || kind === 'audiooutput')) {
+        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
           return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
         }
 
-        if (video && kind === 'videoinput') {
+        if (video && kind === "videoinput") {
           return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
         }
 
@@ -2043,16 +2069,31 @@ function enumerateAudioDevices() {
   return enumerateDevices({ audio: true });
 }
 
+/**
+ * Sets the ID of the audio device to use for output on the given mediaElement
+ *
+ * @param {HTMLMediaElement} mediaElement - Media element to set an audio output device for
+ * @param {string} sinkId - The MediaDeviceInfo.deviceId of the audio output device.
+ *
+ * @return {Promise}
+ */
 function attachSinkId(mediaElement, sinkId) {
   return new Promise(function (resolve, reject) {
-    if (typeof mediaElement.sinkId !== 'undefined') {
+    if (typeof mediaElement.sinkId !== "undefined") {
       mediaElement.setSinkId(sinkId).then(resolve).catch(reject);
     } else {
-      reject('The browser does not support output device selection.');
+      reject("The browser does not support output device selection.");
     }
   });
 }
 
+/**
+ * Sets the ID of the audio device to use for input in the bounded call
+ *
+ * @param {string} deviceId - The MediaDeviceInfo.deviceId of the audio input device.
+ *
+ * @return {Promise}
+ */
 function setAudioInputDevice(deviceId) {
   var _this2 = this;
 
@@ -2068,7 +2109,7 @@ function setAudioInputDevice(deviceId) {
       var newAudioTrack = audioTracks[0];
 
       var audioSender = _this2.peerConnection.getSenders().find(function (sender) {
-        return sender.track.kind === 'audio';
+        return sender.track.kind === "audio";
       });
 
       audioSender.replaceTrack(newAudioTrack).then(resolve).catch(reject);
@@ -2076,6 +2117,14 @@ function setAudioInputDevice(deviceId) {
   });
 }
 
+/**
+ * Sets the ID of the video device to use for input in the bounded call
+ *
+ * @param {string} deviceId - The MediaDeviceInfo.deviceId of the video input device.
+ *
+ * @return {Promise}
+ */
+// eslint-disable-next-line no-unused-vars
 function setVideoInputDevice(deviceId) {
   var _this3 = this;
 
@@ -2091,7 +2140,7 @@ function setVideoInputDevice(deviceId) {
       var newVideoTrack = videoTracks[0];
 
       var videoSender = _this3.peerConnection.getSenders().find(function (sender) {
-        return sender.track.kind === 'Video';
+        return sender.track.kind === "video";
       });
 
       videoSender.replaceTrack(newVideoTrack).then(resolve).catch(reject);
@@ -2099,6 +2148,13 @@ function setVideoInputDevice(deviceId) {
   });
 }
 
+/**
+ * Sets the ID of the audio device to use for output in the bounded call
+ *
+ * @param {string} device - The MediaDeviceInfo.deviceId of the audio output device.
+ *
+ * @return {Promise}
+ */
 function setAudioOutputDevice(deviceId) {
   return attachSinkId(this.remoteAudioVideo, deviceId);
 }
@@ -2375,9 +2431,9 @@ function setRemoteDescription(sdp) {
     type: "answer",
     sdp: sdp
   }, function () {
-    console.log("ok");
+    _Logger2.default.log("ok");
   }, function (error) {
-    console.log("err");
+    _Logger2.default.log("err", error);
   }));
 }
 

--- a/samples/apikey_check/console.html
+++ b/samples/apikey_check/console.html
@@ -14,11 +14,9 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     alert("Success !");

--- a/samples/apikey_check/index.html
+++ b/samples/apikey_check/index.html
@@ -39,7 +39,6 @@
         console.log("Checking...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             alert("Success !");

--- a/samples/apikey_check_and_login/console.html
+++ b/samples/apikey_check_and_login/console.html
@@ -14,12 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var userid = "johndoe";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   userKeys: {
     command: "auth",

--- a/samples/apikey_check_and_login/index.html
+++ b/samples/apikey_check_and_login/index.html
@@ -68,7 +68,6 @@
 
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           userKeys: {
             command: "auth",

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -145,7 +145,6 @@
 
           APIdazeClientObj = new APIdaze.CLIENT({
             apiKey: apikeyTextObj.value,
-            wsurl: "wss://fs-de-fra-2.apidaze.io:8082",
             debug: true,
             onReady: function(sessionObj) {
               joinRoomButtonObj.disabled = false;

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -111,6 +111,12 @@
       var conferenceCall = null;
 
       function gotDevices(deviceInfos) {
+        selectors.forEach(select => {
+          while (select.firstChild) {
+            select.removeChild(select.firstChild);
+          }
+        });
+
         for (const deviceInfo of deviceInfos) {
           const option = document.createElement('option');
           option.value = deviceInfo.deviceId;
@@ -127,7 +133,10 @@
 
       function changeAudioDestination(event) {
         const audioDestination = event.target.value;
-        conferenceCall.setAudioOutputDevice(audioDestination);
+
+        if (conferenceCall) {
+          conferenceCall.setAudioOutputDevice(audioDestination);
+        }
       }
 
       audioOutputSelect.onchange = changeAudioDestination;
@@ -136,7 +145,9 @@
       audioInputSelect.onchange = function (event) {
         const audioInputDeviceId = event.target.value;
 
-        conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        if (conferenceCall) {
+          conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        }
       };
 
       checkButtonObj.onclick = function() {
@@ -148,6 +159,13 @@
             debug: true,
             onReady: function(sessionObj) {
               joinRoomButtonObj.disabled = false;
+
+              // populate user media devices
+              APIdazeClientObj
+                .enumerateAudioDevices()
+                .then(gotDevices);
+
+              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             },
             onError: function(errorMessage){
               alert("Got error : " + errorMessage);
@@ -163,6 +181,8 @@
           {
             command: "joinRoom",
             userName: "guest",
+            audioInputDeviceId: audioInputSelect.value,
+            audioOutputDeviceId: audioOutputSelect.value,
           },
           {
             onRoomMembersInitialList: function(members) {
@@ -183,14 +203,6 @@
               console.log('I left the room');
               joinRoomButtonObj.disabled = false;
               leaveRoomButtonObj.disabled = true;
-            },
-            onAnswer: function() {
-              // populate user media devices
-              conferenceCall
-                .enumerateAudioDevices()
-                .then(gotDevices);
-
-              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             }
           }
         );

--- a/samples/receive_text/console.html
+++ b/samples/receive_text/console.html
@@ -14,13 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var ws_server = "fs-us-ny-1.apidaze.io:8082";
-var wsurl = "wss://" + ws_server;
 var userid = "johndoe";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   userKeys: {
     command: "auth",
@@ -29,7 +26,7 @@ var APIdazeClientObj = new APIdaze.CLIENT({
   onReady: function() {
     console.log("Logged in !");
     console.log("You may now just run the following cURL command to receive text here");
-    console.log("curl -X POST 'https://api4.apidaze.io/" + apiKey + "/chat/send' --data 'api_secret=YOURAPISECRET&from=me&to=" + userid + "&ws_server=" + ws_server + "&text=Hello'")
+    console.log("curl -X POST 'https://api4.apidaze.io/" + apiKey + "/chat/send' --data 'api_secret=YOURAPISECRET&from=me&to=" + userid + "&ws_server=" + APIdazeClientObj._wsUrl + "&text=Hello'")
   },
   onExternalMessageReceived(messageObj) {
     console.log("Received", JSON.stringify(messageObj));

--- a/samples/receive_text/index.html
+++ b/samples/receive_text/index.html
@@ -65,7 +65,6 @@
 
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           userKeys: userKeys,
           onReady: function(sessionObj) {

--- a/samples/rtt_to_server/console.html
+++ b/samples/rtt_to_server/console.html
@@ -14,7 +14,6 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var rttInterval = null;
 
 var stopRTT = function() {
@@ -41,7 +40,6 @@ var startRTT = function() {
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     startRTT();

--- a/samples/rtt_to_server/index.html
+++ b/samples/rtt_to_server/index.html
@@ -51,7 +51,6 @@
         console.log("Connecting...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             alert("Success !");

--- a/samples/send_text/console.html
+++ b/samples/send_text/console.html
@@ -14,12 +14,10 @@
 */
 
 var apiKey = "YOUR_API_KEY";
-var wsurl = "wss://fs-us-ny-1.apidaze.io:8082";
 var text = "Hello there";
 
 var APIdazeClientObj = new APIdaze.CLIENT({
   apiKey: apiKey,
-  wsurl: wsurl,
   debug: true,
   onReady: function() {
     APIdazeClientObj.sendText({

--- a/samples/send_text/index.html
+++ b/samples/send_text/index.html
@@ -73,7 +73,6 @@
         console.log("Checking...");
         APIdazeClientObj = new APIdaze.CLIENT({
           apiKey: apikeyTextObj.value,
-          wsurl: "wss://fs-us-ny-1.apidaze.io:8082",
           debug: true,
           onReady: function() {
             APIdazeClientObj.sendText({

--- a/src/CLIENT.js
+++ b/src/CLIENT.js
@@ -8,12 +8,20 @@ var STATUS_READY = 2;
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT |";
 var LOGGER = new Logger(false, LOG_PREFIX);
 
+const REGIONS = {
+  "us-east": "us1",
+  "us-west": "us2",
+  "eu-central": "eu1",
+  "eu-west": "eu2",
+  "ap-southeast": "ap1"
+};
+
 var CLIENT = function(configuration = {}) {
   let {
     apiKey,
-    wsurl,
-    forcewsurl,
+    wsurl = undefined,
     sessid = null,
+    region = undefined,
     onReady,
     onDisconnected,
     onError,
@@ -80,8 +88,8 @@ var CLIENT = function(configuration = {}) {
     this._onError({ origin: "CLIENT", message: "WebSocket not supported" });
   }
 
-  if (/wss:\/\//.test(forcewsurl)) {
-    wsurl = forcewsurl;
+  if (!wsurl) {
+    wsurl = computeWebsocketServerUrl(region);
   }
 
   // WebSocket URLs must start with wss:// or ws://localhost (the latter
@@ -723,6 +731,20 @@ const ping = function(userCallback) {
   };
 
   this._sendMessage(JSON.stringify(request));
+};
+
+const computeWebsocketServerUrl = function(region = undefined) {
+  const defaultServerUrl = "wss://webrtc.apidaze.io:4062";
+
+  if (region) {
+    const regionSubdomain = REGIONS[region];
+
+    if (regionSubdomain) {
+      return `wss://webrtc.${regionSubdomain}.apidaze.io:4062`;
+    }
+  }
+
+  return defaultServerUrl;
 };
 
 export default CLIENT;

--- a/src/Call.js
+++ b/src/Call.js
@@ -27,11 +27,11 @@ var Call = function(clientObj, callID, params, listeners) {
   var {
     activateAudio = true,
     tagId = "apidaze-audio-video-container-id-" + randomString,
-    audioParams = {},
+    audioParams = {}
   } = params;
 
   const videoParams = {
-    activateScreenShare: false,
+    activateScreenShare: false
   };
 
   if (videoParams.activateScreenShare === true) {
@@ -151,7 +151,7 @@ var Call = function(clientObj, callID, params, listeners) {
   }
 
   var GUMConstraints = {
-    audio: this.activateAudio,
+    audio: this.activateAudio
   };
 
   if (this.activateVideo === false) {
@@ -326,20 +326,23 @@ function enumerateDevices({ audio = true, video = false }) {
   return new Promise((resolve, reject) => {
     navigator.mediaDevices
       .enumerateDevices()
-      .then((devices) => {
-        const filteredDevices = devices.reduce((reducedDevices, currentDevice) => {
-          const { kind } = currentDevice;
+      .then(devices => {
+        const filteredDevices = devices.reduce(
+          (reducedDevices, currentDevice) => {
+            const { kind } = currentDevice;
 
-          if (audio && (kind === 'audioinput' || kind === 'audiooutput')) {
-            return [ ...reducedDevices, currentDevice ];
-          }
+            if (audio && (kind === "audioinput" || kind === "audiooutput")) {
+              return [...reducedDevices, currentDevice];
+            }
 
-          if (video && kind === 'videoinput') {
-            return [ ...reducedDevices, currentDevice ];
-          }
+            if (video && kind === "videoinput") {
+              return [...reducedDevices, currentDevice];
+            }
 
-          return reducedDevices;
-        }, []);
+            return reducedDevices;
+          },
+          []
+        );
 
         resolve(filteredDevices);
       })
@@ -366,12 +369,13 @@ function enumerateAudioDevices() {
  */
 function attachSinkId(mediaElement, sinkId) {
   return new Promise((resolve, reject) => {
-    if (typeof mediaElement.sinkId !== 'undefined') {
-      mediaElement.setSinkId(sinkId)
+    if (typeof mediaElement.sinkId !== "undefined") {
+      mediaElement
+        .setSinkId(sinkId)
         .then(resolve)
         .catch(reject);
     } else {
-      reject('The browser does not support output device selection.');
+      reject("The browser does not support output device selection.");
     }
   });
 }
@@ -393,13 +397,13 @@ function setAudioInputDevice(deviceId) {
           }
         }
       })
-      .then((stream) => {
+      .then(stream => {
         const audioTracks = stream.getAudioTracks();
         const newAudioTrack = audioTracks[0];
 
         const audioSender = this.peerConnection
           .getSenders()
-          .find((sender) => sender.track.kind === 'audio');
+          .find(sender => sender.track.kind === "audio");
 
         audioSender
           .replaceTrack(newAudioTrack)
@@ -428,13 +432,13 @@ function setVideoInputDevice(deviceId) {
           }
         }
       })
-      .then((stream) => {
+      .then(stream => {
         const videoTracks = stream.getVideoTracks();
         const newVideoTrack = videoTracks[0];
 
         const videoSender = this.peerConnection
           .getSenders()
-          .find((sender) => sender.track.kind === 'Video');
+          .find(sender => sender.track.kind === "video");
 
         videoSender
           .replaceTrack(newVideoTrack)

--- a/tests/CLIENT.test.js
+++ b/tests/CLIENT.test.js
@@ -3,7 +3,7 @@ var should = require('should');
 var expect = require('chai').expect;
 var path = require('path');
 
-require('./setup_ws_server.js');
+import { prepareMockWebsocketServer } from './setup_ws_server.js';
 
 import { WebSocket, Server } from 'mock-socket';
 
@@ -20,29 +20,37 @@ describe('CLIENT', function() {
         expect(error).to.eql({ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'});
       }
     });
-    it("should throw exception  {ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'}", function() {
-      try {
-        var client = new APIdaze.CLIENT({});
-      } catch(error){
-        expect(error).to.eql({ok: false, message: 'Please provide an apiKey', origin: 'CLIENT'});
-      }
-    });
   });
-  describe('#new CLIENT({apiKey: "testapikey"}), no WebSocket URL', function() {
+
+  describe('#new CLIENT({apiKey: "testapikey"}), valid apiKey and no region preference', function() {
+    it("should have _wsUrl set with its default value", function(done) {
+      this.timeout(50000);
+      var client = new APIdaze.CLIENT({
+        apiKey: "testingIfApiKeyIsValid",
+        onReady: function(){
+          expect(client._wsUrl).to.equal("wss://webrtc.apidaze.io:4062");
+
+          client.shutdown();
+          done();
+        }
+      });
+    })
+  });
+
+  describe('#new CLIENT({apiKey: "testapikey"}), WebSocket URL with ws protocol', function() {
     it("should throw exception  {ok: false, message: 'Wrong WebSocket URL, must start with wss://', origin: 'CLIENT'}", function() {
       try {
-        var client = new APIdaze.CLIENT({apiKey: "testapikey"});
+        var client = new APIdaze.CLIENT({apiKey: "testapikey", wsurl: "ws://webrtc.apidaze.io:4062"});
       } catch(error){
         expect(error).to.eql({ok: false, message: 'Wrong WebSocket URL, must start with wss://', origin: 'CLIENT'});
       }
     });
   });
-  describe('#new CLIENT({apiKey: "apiKeyWithoutExternalScript", wsurl: "ws://localhost:9080"}), No External Script configured', function() {
+
+  describe('#new CLIENT({apiKey: "apiKeyWithoutExternalScript"}), No External Script configured', function() {
     it("should throw exception  {ok: false, message: Not allowed to login', origin: 'CLIENT'}", function(done) {
       var client = new APIdaze.CLIENT({
-        debug: true,
         apiKey: "apiKeyWithoutExternalScript",
-        wsurl: "ws://localhost:9080",
         onError: function(error){
           console.log("Error : ", error);
           expect(error).to.eql("Not allowed to login");
@@ -52,12 +60,29 @@ describe('CLIENT', function() {
       });
     });
   });
-  describe('#new CLIENT({apiKey:"apiKeyIsValid", wsurl: "ws://localhost:9080"}), valid apiKey and WebSocket URL', function() {
+
+  describe('#new CLIENT({apiKey:"apiKeyIsValid", wsurl: "wss://webrtc.apidaze.io:4062"}), valid apiKey and WebSocket URL', function() {
     it("should call onReady handler if present", function(done) {
       var client = new APIdaze.CLIENT({
-        debug: true,
         apiKey: "testingIfApiKeyIsValid",
-        wsurl: "ws://localhost:9080",
+        onReady: function(){
+          console.log("Ready");
+          client.shutdown();
+          done();
+        }
+      });
+    });
+  });
+
+  describe.only('#new CLIENT({apiKey:"apiKeyIsValid", region: "us-west"}), valid apiKey and region', function() {
+    before(() => {
+      prepareMockWebsocketServer("wss://webrtc.us2.apidaze.io:4062")
+    })
+
+    it("should call onReady handler if present", function(done) {
+      var client = new APIdaze.CLIENT({
+        apiKey: "testingIfApiKeyIsValid",
+        region: "us-west",
         onReady: function(){
           console.log("Ready");
           client.shutdown();

--- a/tests/setup_ws_server.js
+++ b/tests/setup_ws_server.js
@@ -42,8 +42,8 @@ function clientReadyResponse(sessid) {
 	}
 }
 
-before(() => {
-	const mockServer = new Server('ws://localhost:9080');
+export function prepareMockWebsocketServer(serverUrl) {
+	const mockServer = new Server(serverUrl);
 	mockServer.on('connection', (server) => {
 		console.log("[WsServer] Got connection");
 	});
@@ -60,18 +60,23 @@ before(() => {
 
 		console.log("[WsServer] received message :", JSONMessage);
 		switch (params.apiKey) {
-			case "apiKeyWithoutExternalScript":
-			console.log("[WsServer] No External Script for this apiKey");
-			mockServer.send(JSON.stringify(invalidExternalScriptResponse()))
-			return;
-			case "testingIfApiKeyIsValid":
-			console.log("[WsServer] Valid API key");
-			// API key validated
-			mockServer.send(JSON.stringify(genericPongResponse(sessid)));
-			mockServer.send('{"wsp_version":"1","id":11925,"method":"verto.clientReady","params":{"reattached_sessions":[],"id":"f28d6fc8-b96d-11e7-85cd-ebd8388b16c8","sessid":"f28d6fc8-b96d-11e7-85cd-ebd8388b16c8"}}');
-			return;
-			default:
-			console.log("[WsServer] apiKey is valid")
+			case "apiKeyWithoutExternalScript":{
+				console.log("[WsServer] No External Script for this apiKey");
+				mockServer.send(JSON.stringify(invalidExternalScriptResponse()))
+				break;
+			}
+			case "testingIfApiKeyIsValid": {
+				console.log("[WsServer] Valid API key");
+				// API key validated
+				mockServer.send(JSON.stringify(genericPongResponse(sessid)));
+				mockServer.send(JSON.stringify(clientReadyResponse(sessid)))
+				break;
+			}
+			default: {
+				console.log("[WsServer] apiKey is valid")
+			}
 		}
 	});
-})
+}
+
+before(()  => prepareMockWebsocketServer('wss://webrtc.apidaze.io:4062'));


### PR DESCRIPTION
Added an argument of `region` to choose the servers for the connection on the Client class. One may instantiate a client as follows;

```javascript
new APIdaze.CLIENT({
  apiKey: "api_key_comes_here",
  region: "us-west"
});
```

Besides this argument, we still keep the good old `wsurl` argument to accept an explicit server URL. It's good to note that the `wsurl` argument has precedence over the `region` argument.

Here is a JS snippet to explain the foreseeable behaviors;

```javascript
/**
 * Apidaze client instantiation without any specific region or wsurl argument
 * 
 * This client connects to "wss://webrtc.apidaze.io:4062"
 */
new APIdaze.CLIENT({
  apiKey: "23dh4r56",
});

/**
 * Apidaze client instantiation with a region argument
 * 
 * This client connects to "wss://webrtc.us2.apidaze.io:4062"
 */
new APIdaze.CLIENT({
  apiKey: "23dh4r56",
  region: "us-west"
});

/**
 * Apidaze client instantiation with an invalid region argument
 * 
 * This client connects to "wss://webrtc.apidaze.io:4062" as that
 * server is used by default
 */
new APIdaze.CLIENT({
  apiKey: "23dh4r56",
  region: "us-westtt"
});

/**
 * Apidaze client instantiation with a non-secure wsurl argument
 * 
 * This client tries to connect to "ws://webrtc.apidaze.io:4062" as it is
 * explicitly given. However, it fails to connect as the connection must be secure
 * as in "wss" protocol
 */
new APIdaze.CLIENT({
  apiKey: "23dh4r56",
  wsurl: "ws://webrtc.apidaze.io:4062"
});

/**
 * Apidaze client instantiation with a valid region and wsurl arguments
 * 
 * This client connects to "wss://webrtc.eu2.apidaze.io:4062" as `wsurl` argument
 * has precedence over `region` argument
 */
new APIdaze.CLIENT({
  apiKey: "23dh4r56",
  region: "us-west",
  wsurl: "wss://webrtc.apidaze.io:4062"
});
```

Here is also an image reference of the same snippet;

![apidazejs-region-wsurl](https://user-images.githubusercontent.com/1263419/94805945-7a5d4f00-03ed-11eb-9041-ea84303e980c.png)
