### PR TITLE
feat: Accept initial media device IDs

### DIFF
--- a/lib/APIdaze.js
+++ b/lib/APIdaze.js
@@ -982,6 +982,8 @@ var _Logger2 = _interopRequireDefault(_Logger);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
 var STATUS_INIT = 1;
@@ -1013,12 +1015,17 @@ var CLIENT = function CLIENT() {
       debug = configuration.debug,
       _configuration$userKe = configuration.userKeys,
       userKeys = _configuration$userKe === undefined ? {} : _configuration$userKe,
-      iceServers = configuration.iceServers;
+      _configuration$iceSer = configuration.iceServers,
+      iceServers = _configuration$iceSer === undefined ? [{ urls: "stun:stun.l.google.com:19302" }] : _configuration$iceSer;
+
+
+  if (iceServers === null) {
+    iceServers = [];
+  }
 
   /**
    * Functions exposed to user
    */
-
   this.speedTest = speedTest.bind(this);
   this.ping = ping.bind(this);
   this.shutdown = shutdown.bind(this);
@@ -1026,6 +1033,8 @@ var CLIENT = function CLIENT() {
   this.disconnect = shutdown.bind(this); // disconnect is kept for compatibility reasons
   this.sendText = sendText.bind(this);
   this.getWebsocketServer = getWebsocketServer.bind(this);
+  this.enumerateDevices = enumerateDevices;
+  this.enumerateAudioDevices = enumerateAudioDevices;
 
   // User defined handlers
   this._onDisconnected = function () {
@@ -1715,6 +1724,52 @@ var computeWebsocketServerUrl = function computeWebsocketServerUrl() {
   return defaultServerUrl;
 };
 
+/**
+ * Get the media devices
+ *
+ * @param {Object} options - Options to indicate what kind of devices should be returned
+ * @param {Boolean} [options.audio] - Indicates if audio devices should be included
+ * @param {Boolean} [options.video] - Indicates if video devices should be included
+ *
+ * @return {Promise} Promise object to provide media devices
+ */
+function enumerateDevices(_ref2) {
+  var _ref2$audio = _ref2.audio,
+      audio = _ref2$audio === undefined ? true : _ref2$audio,
+      _ref2$video = _ref2.video,
+      video = _ref2$video === undefined ? false : _ref2$video;
+
+  return new Promise(function (resolve, reject) {
+    navigator.mediaDevices.enumerateDevices().then(function (devices) {
+      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
+        var kind = currentDevice.kind;
+
+
+        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        if (video && kind === "videoinput") {
+          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
+        }
+
+        return reducedDevices;
+      }, []);
+
+      resolve(filteredDevices);
+    }).catch(reject);
+  });
+}
+
+/**
+ * Get the audio devices
+ *
+ * @return {Promise} Promise object to provide audio media devices
+ */
+function enumerateAudioDevices() {
+  return enumerateDevices({ audio: true });
+}
+
 exports.default = CLIENT;
 
 /***/ }),
@@ -1744,11 +1799,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } // eslint-disable-next-line no-unused-vars
-
-
 var __VERSION__ = "3.0.0"; // webpack defineplugin variable
 
+// eslint-disable-next-line no-unused-vars
 var LOG_PREFIX = "APIdaze-" + __VERSION__ + " | CLIENT | Call |";
 var LOGGER = new _Logger2.default(false, LOG_PREFIX);
 
@@ -1769,10 +1822,15 @@ var Call = function Call(clientObj, callID, params, listeners) {
 
   var _params$activateAudio = params.activateAudio,
       activateAudio = _params$activateAudio === undefined ? true : _params$activateAudio,
+      audioInputDeviceId = params.audioInputDeviceId,
+      audioOutputDeviceId = params.audioOutputDeviceId,
+      videoInputDeviceId = params.videoInputDeviceId,
       _params$tagId = params.tagId,
       tagId = _params$tagId === undefined ? "apidaze-audio-video-container-id-" + randomString : _params$tagId,
       _params$audioParams = params.audioParams,
-      audioParams = _params$audioParams === undefined ? {} : _params$audioParams;
+      audioParams = _params$audioParams === undefined ? {} : _params$audioParams,
+      _params$iceServers = params.iceServers,
+      iceServers = _params$iceServers === undefined ? clientObj._iceServers : _params$iceServers;
 
 
   var videoParams = {
@@ -1805,6 +1863,7 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.activateAudio = activateAudio;
   this.videoParams = videoParams;
   this.audioParams = audioParams;
+  this.iceServers = iceServers;
   this.audioVideoTagId = tagId;
 
   var audioVideoDOMContainerObj = document.getElementById(tagId);
@@ -1818,6 +1877,10 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.remoteAudioVideo.controls = false;
   if (this.activateVideo === false) {
     this.remoteAudioVideo.style.display = "none";
+  }
+
+  if (audioOutputDeviceId && typeof audioOutputDeviceId === 'string' && audioOutputDeviceId.length > 0) {
+    attachSinkId(this.remoteAudioVideo, audioOutputDeviceId);
   }
 
   if (audioVideoDOMContainerObj == null) {
@@ -1875,8 +1938,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
   this.startLocalAudio = startLocalAudio;
   this.stopLocalVideo = stopLocalVideo;
   this.startLocalVideo = startLocalVideo;
-  this.enumerateDevices = enumerateDevices;
-  this.enumerateAudioDevices = enumerateAudioDevices;
   this.setAudioInputDevice = setAudioInputDevice;
   this.setAudioOutputDevice = setAudioOutputDevice;
 
@@ -1888,8 +1949,22 @@ var Call = function Call(clientObj, callID, params, listeners) {
     audio: this.activateAudio
   };
 
+  if (this.activateAudio && audioInputDeviceId && typeof audioInputDeviceId === 'string' && audioInputDeviceId.length > 0) {
+    GUMConstraints.audio = {
+      deviceId: {
+        exact: audioInputDeviceId
+      }
+    };
+  }
+
   if (this.activateVideo === false) {
     GUMConstraints.video = false;
+  } else if (videoInputDeviceId && typeof videoInputDeviceId === 'string' && videoInputDeviceId.length > 0) {
+    GUMConstraints.video = {
+      deviceId: {
+        exact: videoInputDeviceId
+      }
+    };
   } else {
     LOGGER.log("Need to set GUMConstraints.video");
     GUMConstraints.video = {
@@ -2022,52 +2097,6 @@ var Call = function Call(clientObj, callID, params, listeners) {
     });
   }
 };
-
-/**
- * Get the media devices
- *
- * @param {Object} options - Options to indicate what kind of devices should be returned
- * @param {Boolean} [options.audio] - Indicates if audio devices should be included
- * @param {Boolean} [options.video] - Indicates if video devices should be included
- *
- * @return {Promise} Promise object to provide media devices
- */
-function enumerateDevices(_ref) {
-  var _ref$audio = _ref.audio,
-      audio = _ref$audio === undefined ? true : _ref$audio,
-      _ref$video = _ref.video,
-      video = _ref$video === undefined ? false : _ref$video;
-
-  return new Promise(function (resolve, reject) {
-    navigator.mediaDevices.enumerateDevices().then(function (devices) {
-      var filteredDevices = devices.reduce(function (reducedDevices, currentDevice) {
-        var kind = currentDevice.kind;
-
-
-        if (audio && (kind === "audioinput" || kind === "audiooutput")) {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        if (video && kind === "videoinput") {
-          return [].concat(_toConsumableArray(reducedDevices), [currentDevice]);
-        }
-
-        return reducedDevices;
-      }, []);
-
-      resolve(filteredDevices);
-    }).catch(reject);
-  });
-}
-
-/**
- * Get the audio devices
- *
- * @return {Promise} Promise object to provide audio media devices
- */
-function enumerateAudioDevices() {
-  return enumerateDevices({ audio: true });
-}
 
 /**
  * Sets the ID of the audio device to use for output on the given mediaElement
@@ -2453,7 +2482,7 @@ function attachStreamToPeerConnection() {
  * function.
  */
 function createPeerConnection() {
-  var pc_config = { iceServers: [{ urls: "stun:stun.l.google.com:19302" }] };
+  var pc_config = { iceServers: this.iceServers };
   var pc_constraints = {
     optional: [{ DtlsSrtpKeyAgreement: true }, { googIPv6: false }],
     mandatory: {

--- a/samples/audio_video_conference/index.html
+++ b/samples/audio_video_conference/index.html
@@ -111,6 +111,12 @@
       var conferenceCall = null;
 
       function gotDevices(deviceInfos) {
+        selectors.forEach(select => {
+          while (select.firstChild) {
+            select.removeChild(select.firstChild);
+          }
+        });
+
         for (const deviceInfo of deviceInfos) {
           const option = document.createElement('option');
           option.value = deviceInfo.deviceId;
@@ -127,7 +133,10 @@
 
       function changeAudioDestination(event) {
         const audioDestination = event.target.value;
-        conferenceCall.setAudioOutputDevice(audioDestination);
+
+        if (conferenceCall) {
+          conferenceCall.setAudioOutputDevice(audioDestination);
+        }
       }
 
       audioOutputSelect.onchange = changeAudioDestination;
@@ -136,7 +145,9 @@
       audioInputSelect.onchange = function (event) {
         const audioInputDeviceId = event.target.value;
 
-        conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        if (conferenceCall) {
+          conferenceCall.setAudioInputDevice(audioInputDeviceId);
+        }
       };
 
       checkButtonObj.onclick = function() {
@@ -148,6 +159,13 @@
             debug: true,
             onReady: function(sessionObj) {
               joinRoomButtonObj.disabled = false;
+
+              // populate user media devices
+              APIdazeClientObj
+                .enumerateAudioDevices()
+                .then(gotDevices);
+
+              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             },
             onError: function(errorMessage){
               alert("Got error : " + errorMessage);
@@ -163,6 +181,8 @@
           {
             command: "joinRoom",
             userName: "guest",
+            audioInputDeviceId: audioInputSelect.value,
+            audioOutputDeviceId: audioOutputSelect.value,
           },
           {
             onRoomMembersInitialList: function(members) {
@@ -183,14 +203,6 @@
               console.log('I left the room');
               joinRoomButtonObj.disabled = false;
               leaveRoomButtonObj.disabled = true;
-            },
-            onAnswer: function() {
-              // populate user media devices
-              conferenceCall
-                .enumerateAudioDevices()
-                .then(gotDevices);
-
-              document.querySelector('#mediaDevices.hidden').classList.remove('hidden');
             }
           }
         );


### PR DESCRIPTION
Introduced the following arguments;

1. `audioInputDeviceId` expects an audio input device ID to be initially used
2. `audioOutputDeviceId` expects an audio output device ID to be initially used
3. `videoInputDeviceId` expects a video input device ID to be initially used.

The arguments above can be passed to a Client instance to be used for all the following calls. If needed, one may use `Call#setAudioInputDevice` and `Call#setAudioOutputDevice` methods to update the respective devices for an ongoing call.

Revisions on the following arguments;

1. `iceServers` now expects to receive an array of `RTCIceServer`. By default, it uses "stun:stun.l.google.com:19302". To disable using the default ICE server, one may pass `[]` or `null`.